### PR TITLE
fix(mcp-proxy): treat upstream HTML as error

### DIFF
--- a/src/app/api/mcp/books/[id]/__tests__/route.test.ts
+++ b/src/app/api/mcp/books/[id]/__tests__/route.test.ts
@@ -24,4 +24,17 @@ describe('GET /api/mcp/books/[id]', () => {
 
         spy.mockRestore();
     });
+
+    it('returns 502 when the upstream returns HTML (Cloudflare challenge)', async () => {
+        const html = '<!DOCTYPE html><html><body>Enable JavaScript and cookies</body></html>';
+        const fakeApi = { api: { getBook: vi.fn().mockResolvedValue({ data: html }) } } as any;
+        const spy = vi.spyOn(route as { createApi: () => Api<unknown> }, 'createApi').mockImplementation(() => fakeApi);
+
+        const res = (await route.GET(new Request('http://localhost/api/mcp/books/1'), { params: { id: '1' } as any })) as Response;
+        expect(res.status).toBe(502);
+        const json = await res.json();
+        expect(json).toEqual({ error: 'Failed to fetch from MCP' });
+
+        spy.mockRestore();
+    });
 });

--- a/src/app/api/mcp/books/[id]/__tests__/route.test.ts
+++ b/src/app/api/mcp/books/[id]/__tests__/route.test.ts
@@ -27,14 +27,28 @@ describe('GET /api/mcp/books/[id]', () => {
 
     it('returns 502 when the upstream returns HTML (Cloudflare challenge)', async () => {
         const html = '<!DOCTYPE html><html><body>Enable JavaScript and cookies</body></html>';
-        const fakeApi = { api: { getBook: vi.fn().mockResolvedValue({ data: html }) } } as any;
-        const spy = vi.spyOn(route as { createApi: () => Api<unknown> }, 'createApi').mockImplementation(() => fakeApi);
 
-        const res = (await route.GET(new Request('http://localhost/api/mcp/books/1'), { params: { id: '1' } as any })) as Response;
-        expect(res.status).toBe(502);
-        const json = await res.json();
-        expect(json).toEqual({ error: 'Failed to fetch from MCP' });
+        // Case A: client returns HTML string in `.data`
+        const fakeApiA = { api: { getBook: vi.fn().mockResolvedValue({ data: html }) } } as any;
+        const spyA = vi.spyOn(route as { createApi: () => Api<unknown> }, 'createApi').mockImplementation(() => fakeApiA);
 
-        spy.mockRestore();
+        const resA = (await route.GET(new Request('http://localhost/api/mcp/books/1'), { params: { id: '1' } as any })) as Response;
+        expect(resA.status).toBe(502);
+        const jsonA = await resA.json();
+        expect(jsonA).toEqual({ error: 'Failed to fetch from MCP' });
+
+        spyA.mockRestore();
+
+        // Case B: client returns a Response-like object with a text() method that yields HTML
+        const fakeResponseLike = { status: 403, text: vi.fn().mockResolvedValue(html) } as any;
+        const fakeApiB = { api: { getBook: vi.fn().mockResolvedValue({ data: fakeResponseLike }) } } as any;
+        const spyB = vi.spyOn(route as { createApi: () => Api<unknown> }, 'createApi').mockImplementation(() => fakeApiB);
+
+        const resB = (await route.GET(new Request('http://localhost/api/mcp/books/1'), { params: { id: '1' } as any })) as Response;
+        expect(resB.status).toBe(502);
+        const jsonB = await resB.json();
+        expect(jsonB).toEqual({ error: 'Failed to fetch from MCP' });
+
+        spyB.mockRestore();
     });
 });

--- a/src/app/authors/[id]/page.tsx
+++ b/src/app/authors/[id]/page.tsx
@@ -46,6 +46,13 @@ export default async function AuthorPage({ params }: { params: { id: string } | 
         );
     } catch (e: unknown) {
         console.error('Failed to fetch author', e);
-        return <main className="p-6">Author not found</main>;
+        const msg = e instanceof Error ? e.message : String(e);
+        return (
+            <main className="p-6">
+                <h2 className="text-lg font-semibold">Author not found</h2>
+                <p className="mt-2 text-sm text-red-600">{msg}</p>
+                <p className="mt-2">Go back to the <Link href="/authors" className="text-[var(--color-norwegian-700)] hover:underline dark:text-[var(--color-white)]">authors list</Link>.</p>
+            </main>
+        );
     }
 }

--- a/src/lib/__tests__/mcp.test.ts
+++ b/src/lib/__tests__/mcp.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@bryandebaun/mcp-client', () => ({ Api: vi.fn() }));
+
+describe('createApi header behavior', () => {
+    afterEach(async () => {
+        vi.resetModules();
+        delete process.env.MCP_API_KEY;
+        const { Api } = await import('@bryandebaun/mcp-client');
+        if ((Api as any).mock && typeof (Api as any).mockReset === 'function') {
+            (Api as any).mockReset();
+        }
+    });
+
+    it('includes x-mcp-api-key header when MCP_API_KEY is set', async () => {
+        process.env.MCP_API_KEY = 'super-secret';
+        // import after setting env so module reads it fresh
+        const { createApi } = await import('@/lib/mcp');
+        createApi();
+        const { Api } = await import('@bryandebaun/mcp-client');
+        const callArg = (Api as any).mock.calls[0][0];
+        expect(callArg.headers['x-mcp-api-key']).toBe('super-secret');
+    });
+
+    it('does not include x-mcp-api-key header when MCP_API_KEY is not set', async () => {
+        delete process.env.MCP_API_KEY;
+        const { createApi } = await import('@/lib/mcp');
+        createApi();
+        const { Api } = await import('@bryandebaun/mcp-client');
+        const callArg = (Api as any).mock.calls[0][0];
+        expect(callArg.headers['x-mcp-api-key']).toBeUndefined();
+    });
+});

--- a/src/lib/__tests__/mcp.test.ts
+++ b/src/lib/__tests__/mcp.test.ts
@@ -12,22 +12,22 @@ describe('createApi header behavior', () => {
         }
     });
 
-    it('includes x-mcp-api-key header when MCP_API_KEY is set', async () => {
+    it('includes Authorization bearer header when MCP_API_KEY is set', async () => {
         process.env.MCP_API_KEY = 'super-secret';
         // import after setting env so module reads it fresh
         const { createApi } = await import('@/lib/mcp');
         createApi();
         const { Api } = await import('@bryandebaun/mcp-client');
         const callArg = (Api as any).mock.calls[0][0];
-        expect(callArg.headers['x-mcp-api-key']).toBe('super-secret');
+        expect(callArg.headers['Authorization']).toBe('Bearer super-secret');
     });
 
-    it('does not include x-mcp-api-key header when MCP_API_KEY is not set', async () => {
+    it('does not include Authorization header when MCP_API_KEY is not set', async () => {
         delete process.env.MCP_API_KEY;
         const { createApi } = await import('@/lib/mcp');
         createApi();
         const { Api } = await import('@bryandebaun/mcp-client');
         const callArg = (Api as any).mock.calls[0][0];
-        expect(callArg.headers['x-mcp-api-key']).toBeUndefined();
+        expect(callArg.headers['Authorization']).toBeUndefined();
     });
 });

--- a/src/lib/__tests__/services-fallback.test.ts
+++ b/src/lib/__tests__/services-fallback.test.ts
@@ -1,0 +1,84 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+// Force server-side branch by removing window
+const originalWindow = (global as any).window;
+
+vi.mock('@/lib/mcp', () => {
+    return {
+        createApi: vi.fn(),
+    };
+});
+
+vi.mock('@/lib/server-fetch', () => {
+    return {
+        fetchWithFallback: vi.fn(),
+    };
+});
+
+import { fetchWithFallback } from '@/lib/server-fetch';
+
+// ensure the mock implementation is set before each test
+const proxyResponses = (url: string) => {
+    if (url.startsWith('/api/mcp/books/')) {
+        return new Response(JSON.stringify({ id: 1, title: 'proxied book' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+        });
+    }
+
+    if (url === '/api/mcp/books') {
+        return new Response(JSON.stringify({ books: [{ id: 1, title: 'proxied list' }] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+        });
+    }
+
+    if (url.startsWith('/api/mcp/ratings')) {
+        return new Response(JSON.stringify({ ratings: [{ id: 1, rating: 7 }] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+        });
+    }
+
+    return new Response('{}', { status: 404 });
+};
+
+
+import { createApi } from '@/lib/mcp';
+import { listBooks, getBookById } from '@/lib/services/books';
+import { listRatings } from '@/lib/services/ratings';
+
+describe('services fallback behavior (server-side)', () => {
+    beforeEach(() => {
+        (global as any).window = undefined;
+        // set the implementation for the proxy responses each test
+        (fetchWithFallback as any).mockImplementation(async (url: string) => proxyResponses(url));
+    });
+
+    afterEach(() => {
+        (global as any).window = originalWindow;
+        (createApi as any).mockReset();
+    });
+
+    it('falls back to proxy when listBooks returns HTML-like payload', async () => {
+        // Mock createApi to return an object whose api.listBooks resolves to an Axios-like object
+        (createApi as any).mockImplementation(() => ({ api: { listBooks: async () => ({ data: '<!doctype html>challenge' }) } }));
+
+        const books = await listBooks();
+        expect(books).toEqual([{ id: 1, title: 'proxied list' }]);
+    });
+
+    it('falls back to proxy when getBookById returns HTML-like payload', async () => {
+        (createApi as any).mockImplementation(() => ({ api: { getBook: async () => ({ data: '<html>not json</html>' }) } }));
+
+        const book = await getBookById(1);
+        expect(book).toEqual({ id: 1, title: 'proxied book' });
+    });
+
+    it('falls back to proxy when listRatings returns HTML-like payload', async () => {
+        (createApi as any).mockImplementation(() => ({ api: { listRatings: async () => ({ data: '<html>bot</html>' }) } }));
+
+        const ratings = await listRatings({ bookId: 1 });
+        expect(ratings).toEqual([{ id: 1, rating: 7 }]);
+    });
+});

--- a/src/lib/mcp-proxy.ts
+++ b/src/lib/mcp-proxy.ts
@@ -15,15 +15,17 @@ export async function looksLikeHtmlPayload(payload: unknown): Promise<boolean> {
         }
 
         if (typeof payload === 'object' && payload !== null) {
-            const maybeData = (payload as any).data;
+            const maybeData = (payload as { data?: unknown }).data;
             if (typeof maybeData === 'string') {
                 const trimmed = maybeData.trim().toLowerCase();
                 if (trimmed.startsWith('<!doctype') || trimmed.startsWith('<html')) return true;
             }
 
-            if (typeof (payload as any).text === 'function') {
+            const textFn = (payload as { text?: unknown }).text;
+            if (typeof textFn === 'function') {
                 try {
-                    const txt = await (payload as any).text();
+                    // `textFn` may be synchronous or return a Promise (Response-like). Await its result.
+                    const txt = await (textFn as () => Promise<unknown>)();
                     if (typeof txt === 'string') {
                         const trimmed = txt.trim().toLowerCase();
                         return trimmed.startsWith('<!doctype') || trimmed.startsWith('<html');

--- a/src/lib/mcp-proxy.ts
+++ b/src/lib/mcp-proxy.ts
@@ -2,6 +2,44 @@ import type { Api as ApiType } from '@bryandebaun/mcp-client';
 import { unwrapApiResponse } from '@/lib/api-response';
 import { createApi } from './mcp';
 
+/**
+ * Return true if the provided payload appears to be an unexpected HTML body.
+ * This will safely handle plain strings, Axios-like objects with a `data` string,
+ * or Response-like objects that expose `text()`.
+ */
+export async function looksLikeHtmlPayload(payload: unknown): Promise<boolean> {
+    try {
+        if (typeof payload === 'string') {
+            const trimmed = payload.trim().toLowerCase();
+            return trimmed.startsWith('<!doctype') || trimmed.startsWith('<html');
+        }
+
+        if (typeof payload === 'object' && payload !== null) {
+            const maybeData = (payload as any).data;
+            if (typeof maybeData === 'string') {
+                const trimmed = maybeData.trim().toLowerCase();
+                if (trimmed.startsWith('<!doctype') || trimmed.startsWith('<html')) return true;
+            }
+
+            if (typeof (payload as any).text === 'function') {
+                try {
+                    const txt = await (payload as any).text();
+                    if (typeof txt === 'string') {
+                        const trimmed = txt.trim().toLowerCase();
+                        return trimmed.startsWith('<!doctype') || trimmed.startsWith('<html');
+                    }
+                } catch {
+                    // ignore text() read errors; treat as not HTML
+                }
+            }
+        }
+
+        return false;
+    } catch {
+        return false;
+    }
+}
+
 export interface ProxyResult<T = unknown> {
     status: number;
     body: T | { error: string };
@@ -21,13 +59,10 @@ export async function proxyCall<T = unknown>(
         const res = await fn(api);
         const payload = unwrapApiResponse<T>(res);
 
-        // Detect unexpected HTML responses (Cloudflare challenge page / bot mitigation)
-        if (typeof payload === 'string') {
-            const trimmed = payload.trim().toLowerCase();
-            if (trimmed.startsWith('<!doctype') || trimmed.startsWith('<html')) {
-                console.error('MCP Proxy error: upstream returned HTML (possible Cloudflare challenge)');
-                return { status: 502, body: { error: 'Failed to fetch from MCP' } };
-            }
+        // Use a shared helper to detect HTML-like payloads (Cloudflare challenge pages, etc.)
+        if (await looksLikeHtmlPayload(payload)) {
+            console.error('MCP Proxy error: upstream returned HTML (possible Cloudflare challenge)');
+            return { status: 502, body: { error: 'Failed to fetch from MCP' } };
         }
 
         return { status: 200, body: payload };

--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -11,10 +11,10 @@ export function createApi() {
         'User-Agent': process.env.MCP_USER_AGENT || 'bryandebaun.dev'
     };
 
-    // If an MCP API key is present in env, send it as a server-only header to identify
-    // requests originating from this site. The MCP server should validate this header.
+    // If an MCP API key is present in env, send it as an Authorization bearer token
+    // in server-to-server requests so the MCP server can validate the caller.
     if (process.env.MCP_API_KEY) {
-        headers['x-mcp-api-key'] = process.env.MCP_API_KEY;
+        headers['Authorization'] = `Bearer ${process.env.MCP_API_KEY}`;
     }
 
     return new Api({ baseURL, headers });

--- a/src/lib/mcp.ts
+++ b/src/lib/mcp.ts
@@ -2,5 +2,20 @@ import { Api } from '@bryandebaun/mcp-client';
 
 export function createApi() {
     const baseURL = process.env.MCP_BASE_URL || 'https://bad-mcp.onrender.com';
-    return new Api({ baseURL });
+
+    // Add safe default headers for server-to-server requests. Cloudflare and other
+    // bot mitigation layers sometimes challenge requests missing an Accept header
+    // or a User-Agent. This reduces the chance of being served an HTML challenge.
+    const headers: Record<string, string> = {
+        'Accept': 'application/json',
+        'User-Agent': process.env.MCP_USER_AGENT || 'bryandebaun.dev'
+    };
+
+    // If an MCP API key is present in env, send it as a server-only header to identify
+    // requests originating from this site. The MCP server should validate this header.
+    if (process.env.MCP_API_KEY) {
+        headers['x-mcp-api-key'] = process.env.MCP_API_KEY;
+    }
+
+    return new Api({ baseURL, headers });
 }

--- a/src/lib/services/authors.ts
+++ b/src/lib/services/authors.ts
@@ -10,7 +10,10 @@ export async function listAuthors(): Promise<AuthorWithBooks[]> {
 
 export async function getAuthorById(id: number): Promise<AuthorWithBooks | null> {
     const res = await fetchWithFallback(`/api/mcp/authors/${id}`);
-    if (!res.ok) return null;
+    if (!res.ok) {
+        const txt = await res.text().catch(() => '');
+        throw new Error(`Failed to fetch author ${id}: ${res.status}${txt ? ` - ${txt}` : ''}`);
+    }
     const author = await res.json();
     return author ?? null;
 }

--- a/src/lib/services/books.ts
+++ b/src/lib/services/books.ts
@@ -1,5 +1,4 @@
 import type { BookWithAuthors, ListBooksResponse } from '@bryandebaun/mcp-client';
-import type { AxiosResponse } from 'axios';
 import { fetchWithFallback } from '@/lib/server-fetch';
 import { createApi } from '@/lib/mcp';
 import { unwrapApiResponse } from '@/lib/api-response';

--- a/src/lib/services/ratings.ts
+++ b/src/lib/services/ratings.ts
@@ -1,5 +1,4 @@
 import type { RatingWithDetails, ListRatingsResponse } from '@bryandebaun/mcp-client';
-import type { AxiosResponse } from 'axios';
 import { fetchWithFallback } from '@/lib/server-fetch';
 import { createApi } from '@/lib/mcp';
 import { unwrapApiResponse } from '@/lib/api-response';


### PR DESCRIPTION
Problem: Upstream MCP sometimes returns an HTML challenge (e.g. Cloudflare) which used to get forwarded to pages resulting in unexpected HTML in the UI.\n\nChanges:\n- Treat upstream HTML responses as failures in the MCP proxy and return 502 + a normalized error body\n- Surface non-OK author fetch errors with status + text so pages show a helpful message\n- Added tests to cover HTML upstream responses\n\nValidation: Build + tests passed locally (77 tests).