### PR TITLE
feat: integration/E2E testing framework — CRUD + test-data lifecycle (#84)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,91 @@
+name: Integration / E2E
+
+# Integration suite (issue #84): admin auth + Books CRUD against the LIVE prod
+# MCP server, plus negative auth cases. WRITES to production data (namespaced
+# `[e2e-<runId>]` + guaranteed teardown) — so it is gated on repo secrets and
+# SKIPS GRACEFULLY when they're absent (e.g. PRs from forks).
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    name: Run integration specs
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      # Map repo secrets into the env the suite reads. On forks these resolve to
+      # empty strings and the preflight gate skips the job (secrets are not
+      # exposed to fork PRs by GitHub).
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+      NEXT_PUBLIC_SITE_URL: http://localhost:3000
+      MCP_BASE_URL: ${{ secrets.MCP_BASE_URL }}
+      MCP_API_KEY: ${{ secrets.MCP_API_KEY }}
+      E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
+      E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
+      E2E_USER_EMAIL: ${{ secrets.E2E_USER_EMAIL }}
+      E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
+    steps:
+      - name: Preflight — are the integration secrets present?
+        id: preflight
+        run: |
+          if [ -z "$MCP_API_KEY" ] || [ -z "$E2E_ADMIN_EMAIL" ] || [ -z "$E2E_USER_EMAIL" ] || [ -z "$NEXT_PUBLIC_SUPABASE_URL" ]; then
+            echo "Integration secrets unavailable (likely a fork). Skipping."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.preflight.outputs.run == 'true'
+
+      - name: Install pnpm
+        if: steps.preflight.outputs.run == 'true'
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        if: steps.preflight.outputs.run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.preflight.outputs.run == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright (chromium)
+        if: steps.preflight.outputs.run == 'true'
+        run: pnpm exec playwright install --with-deps chromium
+        timeout-minutes: 8
+
+      - name: Build
+        if: steps.preflight.outputs.run == 'true'
+        run: pnpm run build
+
+      - name: Start server
+        if: steps.preflight.outputs.run == 'true'
+        run: |
+          pnpm run start &
+          echo "Waiting for localhost:3000..."
+          pnpm dlx wait-on http://localhost:3000 --timeout 60000
+
+      - name: Run integration specs
+        if: steps.preflight.outputs.run == 'true'
+        run: pnpm run test:integration
+
+      - name: Upload Playwright report/traces
+        if: ${{ always() && steps.preflight.outputs.run == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-report
+          path: |
+            playwright-report/**
+            test-results/**
+          retention-days: 14

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -83,6 +83,15 @@ const eslintConfig = defineConfig([
       "no-restricted-syntax": "off",
       "@typescript-eslint/no-explicit-any": "off"
     }
+  },
+  // Playwright fixtures pass values to the runner via a `use()` callback. The
+  // react-hooks plugin mistakes `use` for the React hook and flags valid
+  // fixture definitions; it does not apply to the integration suite.
+  {
+    files: ["tests/integration/**/*.{ts,tsx}"],
+    rules: {
+      "react-hooks/rules-of-hooks": "off"
+    }
   }
 ]);
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "a11y:ci": "tsx scripts/a11y/verify-a11y.ts --url http://localhost:3000 --outDir artifacts/a11y --ci",
     "playwright:install": "pnpm exec playwright install --with-deps",
     "visual:test": "pnpm exec playwright test --config=playwright.config.ts",
+    "test:integration": "playwright test --config=playwright.integration.config.ts",
     "visual:baseline": "tsx scripts/generate-visual-baseline.ts",
     "inspect:ci": "tsx scripts/inspect-diff-ci-run.ts",
     "ci:lighthouse": "lhci autorun",

--- a/playwright.integration.config.ts
+++ b/playwright.integration.config.ts
@@ -1,0 +1,70 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Integration / E2E test config (issue #84).
+ *
+ * Kept deliberately SEPARATE from the visual suite (`playwright.config.ts`,
+ * testDir `tests/visual`, testMatch `**\/*.playwright.ts`). This config owns
+ * `tests/integration` with the `**\/*.spec.ts` naming convention so the two
+ * suites never pick up each other's files.
+ *
+ * These specs exercise real request flows: the Next.js auth + `/api/admin/*`
+ * routes, which proxy writes to the LIVE production MCP server. Safety comes
+ * from run-unique namespacing (`[e2e-<runId>]`) plus guaranteed teardown — see
+ * tests/integration/README.md.
+ */
+
+// Node 24 ships `process.loadEnvFile`; load `.env.local` (gitignored) so the
+// E2E credentials + MCP config are available without an extra dotenv dep. Env
+// vars already present in the process (e.g. CI secrets) win — loadEnvFile does
+// not overwrite existing keys.
+const envLocal = path.resolve(__dirname, '.env.local');
+if (existsSync(envLocal)) {
+    process.loadEnvFile(envLocal);
+}
+
+const baseURL =
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/u, '') ||
+    'http://localhost:3000';
+
+export default defineConfig({
+    testDir: 'tests/integration',
+    testMatch: '**/*.spec.ts',
+    // Writes hit the prod MCP on Render's free tier, which can cold-start.
+    // Give each test generous headroom; per-request timeouts are tuned in the
+    // helpers/fixtures.
+    timeout: 120_000,
+    // CRUD specs share the prod backend; run serially to keep teardown
+    // reasoning simple and avoid cross-test interference on the live data.
+    workers: 1,
+    fullyParallel: false,
+    forbidOnly: !!process.env.CI,
+    retries: 0,
+    reporter: process.env.CI ? [['github'], ['list']] : [['list']],
+    use: {
+        baseURL,
+        trace: 'retain-on-failure',
+    },
+    projects: [
+        {
+            name: 'chromium',
+            // API-only specs need no browser binary, but a single chromium
+            // project keeps parity with the visual suite and allows future
+            // UI-driven specs.
+            use: {},
+        },
+    ],
+    // Start the app only if one isn't already listening on baseURL. Prefer a
+    // prebuilt production server (`pnpm start`) — run `pnpm build` first. If you
+    // are iterating locally with `pnpm dev` already running, this reuses it.
+    webServer: {
+        command: 'pnpm start',
+        url: baseURL,
+        reuseExistingServer: true,
+        timeout: 120_000,
+        stdout: 'pipe',
+        stderr: 'pipe',
+    },
+});

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,85 @@
+# Integration / E2E suite
+
+End-to-end specs that exercise real request flows through the Next.js app:
+admin auth (`requireAdmin`) and Books CRUD via the `/api/admin/*` routes, which
+proxy writes to the **live production MCP server**. Added for
+[issue #84](https://github.com/bryan-debaun/bryandebaun.dev/issues/84).
+
+This is **separate** from the visual/a11y Playwright suite (`tests/visual/`,
+`playwright.config.ts`). Each suite has its own config and file-naming
+convention so they never pick up each other's files:
+
+| Suite       | Config                              | testDir            | match               |
+| ----------- | ----------------------------------- | ------------------ | ------------------- |
+| Visual/a11y | `playwright.config.ts`              | `tests/visual`     | `**/*.playwright.ts`|
+| Integration | `playwright.integration.config.ts`  | `tests/integration`| `**/*.spec.ts`      |
+
+Vitest (`pnpm test`) excludes both directories.
+
+## Running
+
+```bash
+# 1. Build once, so the webServer can `pnpm start` a production server.
+pnpm build
+
+# 2. Run the suite. If nothing is listening on the baseURL, the config starts
+#    `pnpm start` for you (reuseExistingServer: true reuses a dev server if you
+#    already have one running).
+pnpm test:integration
+```
+
+Credentials are read from the gitignored `.env.local` (loaded by the config via
+Node 24's `process.loadEnvFile`). Required keys:
+
+- `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` — `app_metadata.role=admin` (passes `requireAdmin`)
+- `E2E_USER_EMAIL` / `E2E_USER_PASSWORD` — confirmed non-admin (for 403 tests)
+- `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`
+- `MCP_BASE_URL`, `MCP_API_KEY`
+- `NEXT_PUBLIC_SITE_URL` (optional; defaults to `http://localhost:3000`)
+
+If required keys are missing the specs **skip** rather than fail — so forks and
+contributors without secrets aren't blocked.
+
+## Specs
+
+- **`auth-negative.spec.ts`** — the priority suite. Anonymous → 401 and
+  non-admin → 403 on the guarded admin routes. No backend writes; must always
+  pass. (Note: `/api/admin/books` has only `POST`, so these assert against the
+  routes that actually run `requireAdmin`, not a non-existent admin `GET`.)
+- **`admin-books.crud.spec.ts`** — admin create → read (get + list) → update →
+  delete → assert-gone, against the live MCP. Namespaced + torn down.
+- **`mcp-auth-probe.spec.ts`** — diagnostic: hits the MCP server's
+  `POST /api/books` directly with three auth shapes and logs whether the server
+  trusts the Supabase admin JWT for writes (the #84 server-side blocker). Folds
+  in the retired `agent-artifacts/probe-mcp-admin-auth.ts`.
+
+## Safety model — why this can write to prod
+
+Writes go to the **real** MCP server (no staging backend exists). Three layers
+keep production clean:
+
+1. **Run-unique namespacing.** Every record this suite creates is titled
+   `[e2e-<runId>]` where `runId` is a per-run timestamp + random suffix. Test
+   data is always visually distinguishable and attributable to a run.
+2. **Guaranteed teardown.** A `TestData` tracker registers every created id and
+   `cleanup()` deletes them in `afterAll` — even when a test fails. The CRUD
+   spec also untracks records it deletes itself so cleanup never double-deletes.
+3. **Pre-run sweeper.** `sweepLeftovers()` runs before the CRUD spec and reaps
+   any `[e2e-` books left behind by a crashed prior run.
+
+### Books-only by design
+
+The website exposes admin **create/update/delete for books**, but only
+**create** for authors (`POST /api/admin/authors`; there is no admin author
+update/delete route). Because authors can't be deleted through the site, the
+suite **never creates authors** — every record it makes must be tearable-down so
+we never orphan data. There is therefore no `admin-authors.crud.spec.ts`. If an
+admin author delete route is added later, mirror `admin-books.crud.spec.ts`.
+
+## CI
+
+`.github/workflows/integration.yml` runs on `workflow_dispatch` and PRs. A
+preflight step checks for the required secrets and **skips the whole job** when
+they're absent (forks), so it never fails for lack of credentials. When secrets
+are present it builds, starts the server, and runs `pnpm test:integration`,
+uploading the Playwright report/traces as an artifact.

--- a/tests/integration/admin-books.crud.spec.ts
+++ b/tests/integration/admin-books.crud.spec.ts
@@ -1,0 +1,117 @@
+import type {
+    BookWithAuthors,
+    ListBooksResponse,
+} from '@bryandebaun/mcp-client';
+import { MCP_REQ_TIMEOUT, expect, test } from './fixtures/auth';
+import { missingEnvKeys } from './fixtures/env';
+import { TestData, sweepLeftovers } from './helpers/factories';
+
+/**
+ * Admin Books CRUD happy path against the LIVE prod MCP server, folding in the
+ * logic from the retired one-off `agent-artifacts/verify-admin-crud.ts`:
+ *   create (201) -> assert present in list + get -> edit (200) -> assert ->
+ *   delete (204) -> assert gone.
+ *
+ * Safety model: every record is namespaced `[e2e-<runId>]`; a pre-run sweep
+ * reaps leftovers from crashed runs; a `finally` block deletes everything this
+ * test created even if an assertion failed. See tests/integration/README.md.
+ *
+ * Why everything lives inside the test body (not beforeAll): the `adminRequest`
+ * fixture is test-scoped, so its APIRequestContext is disposed once the test
+ * ends. Capturing it in `beforeAll` and reusing it in the test races against
+ * that teardown. Keeping the whole flow in one test with `finally` cleanup is
+ * both correct and the clearest teardown guarantee.
+ *
+ * If the MCP server rejects the Supabase admin JWT for writes (the #84 blocker),
+ * `createBook` throws on the non-201 and the test fails LOUDLY with the upstream
+ * status — exactly the regression this suite is meant to catch.
+ */
+
+test.beforeAll(() => {
+    const missing = missingEnvKeys();
+    test.skip(
+        missing.length > 0,
+        `Missing integration env: ${missing.join(', ')}`,
+    );
+});
+
+test('Admin Books CRUD (live MCP): create -> read -> update -> delete', async ({
+    adminRequest,
+    runId,
+}) => {
+    const admin = adminRequest;
+    const data = new TestData(admin, runId);
+
+    // Reap any leftovers from a previously crashed run before we start.
+    const swept = await sweepLeftovers(admin);
+    if (swept.books > 0) {
+        console.info(`sweepLeftovers reaped ${swept.books} stale book(s)`);
+    }
+
+    try {
+        // CREATE
+        const created = await data.createBook('crud', {
+            description: 'integration verification record — safe to delete',
+        });
+        expect(created.id).toBeGreaterThan(0);
+        expect(created.title).toBe(`${data.tag()} crud`);
+
+        // READ (get by id)
+        const getRes = await admin.get(`/api/mcp/books/${created.id}`, {
+            failOnStatusCode: false,
+            timeout: MCP_REQ_TIMEOUT,
+        });
+        expect(getRes.ok()).toBeTruthy();
+        const fetched = (await getRes.json()) as BookWithAuthors;
+        expect(fetched.id).toBe(created.id);
+        expect(fetched.title).toBe(created.title);
+
+        // READ (present in list)
+        const listRes = await admin.get('/api/mcp/books?limit=200', {
+            failOnStatusCode: false,
+            timeout: MCP_REQ_TIMEOUT,
+        });
+        expect(listRes.ok()).toBeTruthy();
+        const list = (await listRes.json()) as ListBooksResponse;
+        expect(list.books.some((b) => b.id === created.id)).toBeTruthy();
+
+        // UPDATE
+        const newTitle = `${data.tag()} crud (edited)`;
+        const patchRes = await admin.patch(`/api/admin/books/${created.id}`, {
+            data: { title: newTitle },
+            failOnStatusCode: false,
+            timeout: MCP_REQ_TIMEOUT,
+        });
+        expect(patchRes.status()).toBe(200);
+        const updated = (await patchRes.json()) as { title: string };
+        expect(updated.title).toBe(newTitle);
+
+        // assert the edit persisted
+        const afterEdit = await admin.get(`/api/mcp/books/${created.id}`, {
+            failOnStatusCode: false,
+            timeout: MCP_REQ_TIMEOUT,
+        });
+        expect(afterEdit.ok()).toBeTruthy();
+        expect(((await afterEdit.json()) as BookWithAuthors).title).toBe(
+            newTitle,
+        );
+
+        // DELETE
+        const delRes = await admin.delete(`/api/admin/books/${created.id}`, {
+            failOnStatusCode: false,
+            timeout: MCP_REQ_TIMEOUT,
+        });
+        expect(delRes.status()).toBe(204);
+        data.untrack(created.id); // we deleted it ourselves; don't re-delete
+
+        // assert gone
+        const goneRes = await admin.get(`/api/mcp/books/${created.id}`, {
+            failOnStatusCode: false,
+            timeout: MCP_REQ_TIMEOUT,
+        });
+        expect(goneRes.ok()).toBeFalsy();
+    } finally {
+        // Guaranteed teardown — deletes anything still tracked even on failure.
+        await data.cleanup();
+    }
+});

--- a/tests/integration/auth-negative.spec.ts
+++ b/tests/integration/auth-negative.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from './fixtures/auth';
+import { missingEnvKeys } from './fixtures/env';
+
+/**
+ * Negative auth coverage for `requireAdmin` (src/lib/auth-guard.ts):
+ *   - anonymous  -> 401 Unauthorized
+ *   - non-admin  -> 403 Forbidden
+ *
+ * These exercise only the guard, never the MCP write path, so they must pass
+ * reliably regardless of MCP/backend state. This is the priority suite.
+ *
+ * Endpoint note: `/api/admin/books` defines only POST (no GET handler), so a GET
+ * there returns 405, not a guard status. We therefore assert against the routes
+ * that actually run `requireAdmin`: POST /api/admin/books, POST
+ * /api/admin/authors, and PATCH/DELETE /api/admin/books/[id]. The guard runs
+ * before any body parsing or MCP call, so dummy ids/payloads are fine.
+ */
+
+// Anon/non-admin specs only need login creds for the non-admin context; if E2E
+// creds are absent (e.g. a fork without secrets) skip rather than fail.
+test.beforeAll(() => {
+    const missing = missingEnvKeys();
+    test.skip(
+        missing.length > 0,
+        `Missing integration env: ${missing.join(', ')}`,
+    );
+});
+
+test.describe('requireAdmin — anonymous is rejected with 401', () => {
+    test('POST /api/admin/books -> 401', async ({ anonRequest }) => {
+        const res = await anonRequest.post('/api/admin/books', {
+            data: { title: 'should-be-rejected' },
+            failOnStatusCode: false,
+        });
+        expect(res.status()).toBe(401);
+    });
+
+    test('POST /api/admin/authors -> 401', async ({ anonRequest }) => {
+        const res = await anonRequest.post('/api/admin/authors', {
+            data: { name: 'should-be-rejected' },
+            failOnStatusCode: false,
+        });
+        expect(res.status()).toBe(401);
+    });
+
+    test('PATCH /api/admin/books/[id] -> 401', async ({ anonRequest }) => {
+        const res = await anonRequest.patch('/api/admin/books/1', {
+            data: { title: 'should-be-rejected' },
+            failOnStatusCode: false,
+        });
+        expect(res.status()).toBe(401);
+    });
+
+    test('DELETE /api/admin/books/[id] -> 401', async ({ anonRequest }) => {
+        const res = await anonRequest.delete('/api/admin/books/1', {
+            failOnStatusCode: false,
+        });
+        expect(res.status()).toBe(401);
+    });
+});
+
+test.describe('requireAdmin — authenticated non-admin is rejected with 403', () => {
+    test('POST /api/admin/books -> 403', async ({ userRequest }) => {
+        const res = await userRequest.post('/api/admin/books', {
+            data: { title: 'should-be-rejected' },
+            failOnStatusCode: false,
+        });
+        expect(res.status()).toBe(403);
+    });
+
+    test('POST /api/admin/authors -> 403', async ({ userRequest }) => {
+        const res = await userRequest.post('/api/admin/authors', {
+            data: { name: 'should-be-rejected' },
+            failOnStatusCode: false,
+        });
+        expect(res.status()).toBe(403);
+    });
+
+    test('PATCH /api/admin/books/[id] -> 403', async ({ userRequest }) => {
+        const res = await userRequest.patch('/api/admin/books/1', {
+            data: { title: 'should-be-rejected' },
+            failOnStatusCode: false,
+        });
+        expect(res.status()).toBe(403);
+    });
+
+    test('DELETE /api/admin/books/[id] -> 403', async ({ userRequest }) => {
+        const res = await userRequest.delete('/api/admin/books/1', {
+            failOnStatusCode: false,
+        });
+        expect(res.status()).toBe(403);
+    });
+});

--- a/tests/integration/fixtures/auth.ts
+++ b/tests/integration/fixtures/auth.ts
@@ -1,0 +1,118 @@
+import {
+    type APIRequestContext,
+    request as playwrightRequest,
+    test as base,
+} from '@playwright/test';
+import { getIntegrationEnv, type IntegrationEnv } from './env';
+
+/**
+ * Per-request timeout for any call that proxies to the prod MCP server. Render's
+ * free tier can cold-start, so a wake-up shouldn't fail the run.
+ */
+export const MCP_REQ_TIMEOUT = 90_000;
+
+function resolveBaseURL(): string {
+    return (
+        process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/u, '') ||
+        'http://localhost:3000'
+    );
+}
+
+/**
+ * Logs in against the real `/api/auth/login` route inside a fresh
+ * APIRequestContext. The login route uses @supabase/ssr, which writes the
+ * session as `Set-Cookie` headers on the response; Playwright captures those
+ * into the context's cookie jar, so subsequent `/api/admin/*` calls on the same
+ * context are authenticated exactly as a browser would be.
+ */
+async function loginContext(
+    email: string,
+    password: string,
+): Promise<APIRequestContext> {
+    const ctx = await playwrightRequest.newContext({ baseURL: resolveBaseURL() });
+    const res = await ctx.post('/api/auth/login', {
+        data: { email, password },
+        failOnStatusCode: false,
+        timeout: MCP_REQ_TIMEOUT,
+    });
+    if (res.status() !== 200) {
+        const body = await res.text().catch(() => '');
+        await ctx.dispose();
+        throw new Error(
+            `Login failed for ${email}: ${res.status()} ${body.slice(0, 200)}`,
+        );
+    }
+    return ctx;
+}
+
+export interface IntegrationWorkerFixtures {
+    /** Validated integration environment (credentials + MCP config). */
+    env: IntegrationEnv;
+    /** Authenticated as the e2e admin (passes requireAdmin). Worker-scoped. */
+    adminRequest: APIRequestContext;
+    /** Authenticated as a confirmed non-admin (for 403 tests). Worker-scoped. */
+    userRequest: APIRequestContext;
+}
+
+export interface IntegrationTestFixtures {
+    /** Run-unique id used to namespace test records: `[e2e-<runId>]`. */
+    runId: string;
+    /** Unauthenticated context (for 401 tests). */
+    anonRequest: APIRequestContext;
+}
+
+/**
+ * Auth contexts are WORKER-scoped: each user logs in exactly once per worker
+ * rather than once per test. Supabase Auth rate-limits `signInWithPassword`, and
+ * repeated logins of the same user in quick succession can transiently fail
+ * token validation — worker scope makes the suite both faster and resilient to
+ * that. `env` is worker-scoped too so a worker-scoped fixture may depend on it.
+ */
+export const test = base.extend<
+    IntegrationTestFixtures,
+    IntegrationWorkerFixtures
+>({
+    env: [
+        async ({}, use) => {
+            await use(getIntegrationEnv());
+        },
+        { scope: 'worker' },
+    ],
+
+    adminRequest: [
+        async ({ env }, use) => {
+            const ctx = await loginContext(env.adminEmail, env.adminPassword);
+            await use(ctx);
+            await ctx.dispose();
+        },
+        { scope: 'worker' },
+    ],
+
+    userRequest: [
+        async ({ env }, use) => {
+            const ctx = await loginContext(env.userEmail, env.userPassword);
+            await use(ctx);
+            await ctx.dispose();
+        },
+        { scope: 'worker' },
+    ],
+
+    // A normal test file may use Date.now(); the workflow-script ban does not
+    // apply here. Combine time + a short random suffix so parallel/retried runs
+    // never collide on a namespace.
+    runId: async ({}, use) => {
+        const stamp = Date.now().toString(36);
+        const rand = Math.random().toString(36).slice(2, 6);
+        await use(`${stamp}-${rand}`);
+    },
+
+    anonRequest: async ({}, use) => {
+        const ctx = await playwrightRequest.newContext({
+            baseURL: resolveBaseURL(),
+        });
+        await use(ctx);
+        await ctx.dispose();
+    },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/integration/fixtures/env.ts
+++ b/tests/integration/fixtures/env.ts
@@ -1,0 +1,63 @@
+/**
+ * Centralized access to the environment configuration the integration suite
+ * needs. `.env.local` is loaded by `playwright.integration.config.ts` before
+ * tests run; in CI the same keys arrive as secrets in `process.env`.
+ */
+
+export interface IntegrationEnv {
+    adminEmail: string;
+    adminPassword: string;
+    userEmail: string;
+    userPassword: string;
+    mcpApiKey: string;
+    mcpBaseUrl: string;
+    siteUrl: string;
+}
+
+/** Keys required for the auth fixtures + CRUD specs to run. */
+const REQUIRED_KEYS = [
+    'E2E_ADMIN_EMAIL',
+    'E2E_ADMIN_PASSWORD',
+    'E2E_USER_EMAIL',
+    'E2E_USER_PASSWORD',
+    'MCP_API_KEY',
+    'MCP_BASE_URL',
+] as const;
+
+/**
+ * Returns the list of required env keys that are missing/empty. CI uses this to
+ * SKIP the suite gracefully on forks where secrets are unavailable.
+ */
+export function missingEnvKeys(): string[] {
+    return REQUIRED_KEYS.filter((k) => {
+        const v = process.env[k];
+        return v === undefined || v === '';
+    });
+}
+
+/**
+ * Reads and validates the integration env. Throws a clear error listing any
+ * missing keys — callers that want to skip instead should consult
+ * `missingEnvKeys()` first.
+ */
+export function getIntegrationEnv(): IntegrationEnv {
+    const missing = missingEnvKeys();
+    if (missing.length > 0) {
+        throw new Error(
+            `Integration env missing required keys: ${missing.join(', ')}. ` +
+                'Populate .env.local locally or provide the secrets in CI.',
+        );
+    }
+
+    return {
+        adminEmail: process.env.E2E_ADMIN_EMAIL as string,
+        adminPassword: process.env.E2E_ADMIN_PASSWORD as string,
+        userEmail: process.env.E2E_USER_EMAIL as string,
+        userPassword: process.env.E2E_USER_PASSWORD as string,
+        mcpApiKey: process.env.MCP_API_KEY as string,
+        mcpBaseUrl: (process.env.MCP_BASE_URL as string).replace(/\/+$/u, ''),
+        siteUrl: (
+            process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+        ).replace(/\/+$/u, ''),
+    };
+}

--- a/tests/integration/helpers/factories.ts
+++ b/tests/integration/helpers/factories.ts
@@ -1,0 +1,155 @@
+import type { APIRequestContext } from '@playwright/test';
+import type {
+    Book,
+    BookWithAuthors,
+    ListBooksResponse,
+} from '@bryandebaun/mcp-client';
+import { MCP_REQ_TIMEOUT } from '../fixtures/auth';
+
+/**
+ * Test-data factories + lifecycle management for the integration suite.
+ *
+ * NOTE on scope: the website exposes admin create/update/delete for **books**
+ * (`/api/admin/books`, `/api/admin/books/[id]`) but only **create** for authors
+ * (`/api/admin/authors` POST — there is no admin author update/delete route).
+ * Because we cannot delete authors through the site, we deliberately do NOT
+ * create authors here: every record this suite creates must be tearable-down so
+ * we never orphan data on the prod MCP. Books CRUD is the symmetric surface.
+ */
+
+/** Prefix that marks a record as test-owned so the sweeper can find leftovers. */
+export const E2E_PREFIX = '[e2e-';
+
+/** Build the namespaced label for a given run, e.g. `[e2e-<runId>]`. */
+export function e2eTag(runId: string): string {
+    return `${E2E_PREFIX}${runId}]`;
+}
+
+/** True if a title/name was created by the integration suite (any run). */
+export function isE2eRecord(label: string | undefined | null): boolean {
+    return typeof label === 'string' && label.startsWith(E2E_PREFIX);
+}
+
+interface CreatedRecord {
+    kind: 'book';
+    id: number;
+}
+
+/**
+ * Tracks every record a test creates and guarantees teardown. Construct one per
+ * test (or per file) and call `cleanup()` in afterAll/afterEach — even on
+ * failure — so no orphan `[e2e-` data is ever left on the prod MCP.
+ */
+export class TestData {
+    private readonly created: CreatedRecord[] = [];
+
+    constructor(
+        private readonly admin: APIRequestContext,
+        private readonly runId: string,
+    ) {}
+
+    /** Namespaced label for this test data's run. */
+    tag(): string {
+        return e2eTag(this.runId);
+    }
+
+    /**
+     * Creates a book via `/api/admin/books`, namespaced + registered for
+     * teardown. `suffix` disambiguates multiple records in one test.
+     */
+    async createBook(
+        suffix = 'book',
+        overrides: Record<string, unknown> = {},
+    ): Promise<Book> {
+        const title = `${this.tag()} ${suffix}`;
+        const res = await this.admin.post('/api/admin/books', {
+            data: { title, ...overrides },
+            failOnStatusCode: false,
+            timeout: MCP_REQ_TIMEOUT,
+        });
+        if (res.status() !== 201) {
+            const body = await res.text().catch(() => '');
+            throw new Error(
+                `createBook expected 201, got ${res.status()}: ${body.slice(0, 200)}`,
+            );
+        }
+        const book = (await res.json()) as Book;
+        this.created.push({ kind: 'book', id: book.id });
+        return book;
+    }
+
+    /** Manually register a book id (e.g. created indirectly) for teardown. */
+    track(id: number): void {
+        this.created.push({ kind: 'book', id });
+    }
+
+    /** Forget a book id once a test has deliberately deleted it. */
+    untrack(id: number): void {
+        const idx = this.created.findIndex((r) => r.id === id);
+        if (idx >= 0) this.created.splice(idx, 1);
+    }
+
+    /**
+     * Deletes every still-tracked record. Best-effort and idempotent: a record
+     * a test already deleted (and untracked) is skipped; failures are collected
+     * and surfaced so teardown problems are visible without aborting cleanup.
+     */
+    async cleanup(): Promise<void> {
+        const errors: string[] = [];
+        // Copy + clear first so a re-entrant cleanup is a no-op.
+        const records = this.created.splice(0, this.created.length);
+        for (const rec of records) {
+            const path = `/api/admin/books/${rec.id}`;
+            try {
+                const res = await this.admin.delete(path, {
+                    failOnStatusCode: false,
+                    timeout: MCP_REQ_TIMEOUT,
+                });
+                const ok = res.status() === 204 || res.status() === 200;
+                if (!ok) {
+                    errors.push(`${path} -> ${res.status()}`);
+                }
+            } catch (e) {
+                errors.push(`${path} -> ${(e as Error).message}`);
+            }
+        }
+        if (errors.length > 0) {
+            throw new Error(`cleanup failed for: ${errors.join('; ')}`);
+        }
+    }
+}
+
+/**
+ * Removes stale `[e2e-` books left by crashed prior runs. Reads the public list
+ * endpoint (which the website proxies to the MCP server), then deletes any
+ * test-tagged book via the admin endpoint. Safe to run before a suite; returns
+ * a count for logging.
+ *
+ * Authors are intentionally not swept: the site has no admin author delete, so
+ * the suite never creates authors and there is nothing to reap.
+ */
+export async function sweepLeftovers(
+    admin: APIRequestContext,
+): Promise<{ books: number }> {
+    let books = 0;
+
+    const booksRes = await admin.get('/api/mcp/books?limit=200', {
+        failOnStatusCode: false,
+        timeout: MCP_REQ_TIMEOUT,
+    });
+    if (booksRes.ok()) {
+        const data = (await booksRes.json()) as ListBooksResponse;
+        const stale = (data.books ?? []).filter((b: BookWithAuthors) =>
+            isE2eRecord(b.title),
+        );
+        for (const b of stale) {
+            const del = await admin.delete(`/api/admin/books/${b.id}`, {
+                failOnStatusCode: false,
+                timeout: MCP_REQ_TIMEOUT,
+            });
+            if (del.status() === 204 || del.status() === 200) books += 1;
+        }
+    }
+
+    return { books };
+}

--- a/tests/integration/mcp-auth-probe.spec.ts
+++ b/tests/integration/mcp-auth-probe.spec.ts
@@ -1,0 +1,123 @@
+import { createClient } from '@supabase/supabase-js';
+import { expect, test } from './fixtures/auth';
+import { missingEnvKeys } from './fixtures/env';
+
+/**
+ * MCP server auth probe — folds in the retired one-off
+ * `agent-artifacts/probe-mcp-admin-auth.ts`.
+ *
+ * Isolates website-vs-server: signs in to Supabase as the e2e admin, then hits
+ * the LIVE MCP server's POST /api/books DIRECTLY (the website route is bypassed)
+ * with three auth shapes:
+ *   1. Bearer <Supabase JWT>
+ *   2. Bearer <Supabase JWT> + X-MCP-Api-Key   (the shape src/lib/mcp.ts sends)
+ *   3. Bearer <MCP_API_KEY>
+ *
+ * This proves whether the server trusts the admin JWT for writes — the #84
+ * blocker. It DELETEs anything it manages to create so it never orphans data.
+ * It asserts only that the probe completed and logs a verdict; the website-path
+ * CRUD spec is what gates on writes actually working end to end.
+ */
+
+interface ProbeResult {
+    label: string;
+    status: number;
+    body: string;
+}
+
+test.beforeAll(() => {
+    const missing = missingEnvKeys();
+    test.skip(
+        missing.length > 0,
+        `Missing integration env: ${missing.join(', ')}`,
+    );
+});
+
+test('probe: does the MCP server trust the Supabase admin JWT for writes?', async ({
+    env,
+    runId,
+}) => {
+    const supa = createClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL as string,
+        process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY as string,
+    );
+    const { data, error } = await supa.auth.signInWithPassword({
+        email: env.adminEmail,
+        password: env.adminPassword,
+    });
+    expect(error, error?.message).toBeNull();
+    expect(data.session).not.toBeNull();
+    const jwt = data.session!.access_token;
+
+    const mcp = env.mcpBaseUrl;
+    const created: number[] = [];
+
+    const tryPost = async (
+        label: string,
+        headers: Record<string, string>,
+    ): Promise<ProbeResult> => {
+        const res = await fetch(`${mcp}/api/books`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+                ...headers,
+            },
+            body: JSON.stringify({ title: `[e2e-${runId}] probe` }),
+        });
+        const body = await res.text();
+        if (res.status === 201) {
+            try {
+                const id = (JSON.parse(body) as { id?: number }).id;
+                if (typeof id === 'number') created.push(id);
+            } catch {
+                /* non-JSON body; nothing to track */
+            }
+        }
+        console.info(`  ${label}: ${res.status} — ${body.slice(0, 160)}`);
+        return { label, status: res.status, body };
+    };
+
+    let results: ProbeResult[] = [];
+    try {
+        results = [
+            await tryPost('Bearer <JWT>', { Authorization: `Bearer ${jwt}` }),
+            await tryPost('Bearer <JWT> + X-MCP-Api-Key', {
+                Authorization: `Bearer ${jwt}`,
+                'X-MCP-Api-Key': env.mcpApiKey,
+            }),
+            await tryPost('Bearer <MCP_API_KEY>', {
+                Authorization: `Bearer ${env.mcpApiKey}`,
+            }),
+        ];
+    } finally {
+        // Never orphan probe records, regardless of which auth shape worked.
+        for (const id of created) {
+            await fetch(`${mcp}/api/books/${id}`, {
+                method: 'DELETE',
+                headers: {
+                    Authorization: `Bearer ${jwt}`,
+                    'X-MCP-Api-Key': env.mcpApiKey,
+                },
+            }).catch(() => {});
+        }
+    }
+
+    const jwtAccepted = results
+        .slice(0, 2)
+        .some((r) => r.status === 201);
+    const keyAccepted = results[2]?.status === 201;
+    const verdict = jwtAccepted
+        ? 'Server ACCEPTS the Supabase admin JWT for writes.'
+        : keyAccepted
+          ? 'Server accepts the API key but NOT the JWT for writes.'
+          : 'Server REJECTS all auth shapes for writes.';
+    console.info(`\nMCP write-path verdict: ${verdict}`);
+
+    // Diagnostic spec: assert only that the probe ran and produced statuses, so
+    // it surfaces the verdict without flaking the suite on the known blocker.
+    expect(results).toHaveLength(3);
+    for (const r of results) {
+        expect(typeof r.status).toBe('number');
+    }
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,15 @@ export default defineConfig({
     test: {
         environment: 'jsdom',
         globals: true,
-        setupFiles: ['src/setupTests.ts']
+        setupFiles: ['src/setupTests.ts'],
+        // Vitest owns unit tests only. The Playwright suites have their own
+        // runners/configs — exclude them so `vitest` never tries to execute a
+        // Playwright spec. (Defaults like node_modules/dist are preserved.)
+        exclude: [
+            '**/node_modules/**',
+            '**/dist/**',
+            'tests/visual/**',
+            'tests/integration/**'
+        ]
     }
 });


### PR DESCRIPTION
## Summary

Adds a Playwright-Test **integration/E2E layer** (#84) exercising real request flows: Supabase admin auth → `/api/admin/*` → `mcp.ts` → the live MCP server. Kept fully separate from the existing visual suite.

## What's included

- **`playwright.integration.config.ts`** — `tests/integration`, `**/*.spec.ts`, serial (`workers:1`), loads gitignored `.env.local`, auto-starts `pnpm start` (reuses an existing server). `pnpm test:integration`.
- **Auth fixtures** (`tests/integration/fixtures/`) — `adminRequest`, `userRequest` (worker-scoped to avoid Supabase auth rate-limit flake), `anonRequest`, via the real `/api/auth/login` route so SSR cookies flow through.
- **Test-data lifecycle** (`helpers/factories.ts`) — `TestData.createBook` namespaces records `[e2e-<runId>]`, tracks IDs, and guarantees idempotent `cleanup()`; `sweepLeftovers()` reaps stale records from crashed runs. **Never-orphan guarantee.**
- **Specs**:
  - `auth-negative.spec.ts` — anon → 401, non-admin → 403 across POST `/api/admin/books`, POST `/api/admin/authors`, PATCH/DELETE `/api/admin/books/[id]` (no backend writes).
  - `admin-books.crud.spec.ts` — admin create (201) → get/list assert → update (200) → delete (204) → assert-gone, against the live MCP.
  - `mcp-auth-probe.spec.ts` — folds in the old `probe-mcp-admin-auth.ts`.
- **CI** (`.github/workflows/integration.yml`) — secret-gated; skips gracefully on forks; `workflow_dispatch` + PR.
- Removed throwaway `agent-artifacts/verify-admin-crud.ts` and `probe-mcp-admin-auth.ts` (logic folded in).

## Test-data isolation model

CRUD specs write to the **production MCP** (`bad-mcp.onrender.com`) with run-unique `[e2e-<runId>]` namespacing + guaranteed afterAll teardown + a pre-run sweeper. Auth fixtures use dedicated provisioned Supabase users (`e2e-admin@`, `e2e-user@`); credentials live only in gitignored `.env.local` / CI secrets.

## Verification

- **10/10 integration specs pass** (3 consecutive clean runs); **0 `[e2e-` records remain** after teardown.
- Confirms the historical #84 blocker is **resolved**: the prod MCP admin write path works via the two-factor scheme (Supabase JWT in `Authorization` + gateway key in `X-MCP-Api-Key`) — returns 201/204.
- `pnpm run lint` clean; `vitest --run` 121/121 (integration excluded).

## Scope note

Books-only CRUD by design: the site exposes admin create/update/delete for books but only **create** for authors (no author delete route), so the suite never creates authors — nothing it makes can be left un-torn-down. Negative tests still cover `POST /api/admin/authors`.

Closes #84.
