### PR TITLE
feat: admin users & invites + secure app_metadata guard (#51)

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -20,7 +20,11 @@
         "EMDR",
         "reparenting",
         "Gottman",
-        "Kolk"
+        "Kolk",
+        "Résumé",
+        "résumé",
+        "Supabase",
+        "Resend"
     ],
     "ignorePaths": [
         "node_modules/**",

--- a/docs/adr/0003-supabase-api-keys.md
+++ b/docs/adr/0003-supabase-api-keys.md
@@ -1,0 +1,86 @@
+# ADR 0003 — Supabase API keys & admin auth model
+
+Date: 2026-06-28
+
+Status: Accepted
+
+## Context
+
+The site uses Supabase for authentication and now (issue #51) for privileged
+admin user/invite management. This requires two classes of Supabase API key:
+
+1. A **client-side** key embedded in the browser bundle for public auth flows
+   (login, register, password reset).
+2. A **server-side privileged** key for `auth.admin.*` operations (listing
+   users, generating invite links, deleting pending invites) that bypass Row
+   Level Security.
+
+Historically Supabase issued two JWT-based keys for these roles: the `anon` key
+and the `service_role` key. Both are derived from the project's JWT secret,
+which makes them **hard to rotate** (rotating the JWT secret invalidates every
+key and all issued user sessions at once) and means the high-privilege
+`service_role` key is a single long-lived secret.
+
+In 2025 Supabase introduced a **modern API key system** and now recommends
+migrating off the JWT-based keys:
+
+- **Publishable key** (`sb_publishable_*`) — replaces the `anon` key. Safe for
+  the browser/client.
+- **Secret key** (`sb_secret_*`) — replaces the `service_role` key. Server-only,
+  full access. Multiple named secret keys can be created and **rotated/revoked
+  independently** without touching the JWT secret or user sessions.
+
+Per Supabase's docs, the legacy `anon`/`service_role` keys keep working **until
+the end of 2026**, but switching is "strongly encouraged."
+
+## Decision
+
+- **Client key:** use the modern **publishable key** via
+  `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (`sb_publishable_*`). Already adopted.
+- **Server key:** use the modern **secret key** via `SUPABASE_SECRET_KEY`
+  (`sb_secret_*`) for the server-only admin client
+  (`src/lib/supabase/admin.ts`). The legacy `SUPABASE_SERVICE_ROLE_KEY` is read
+  only as a transitional fallback and should be removed once the secret key is
+  set in all environments.
+- **Authorization role source:** admin authorization is determined by
+  `app_metadata.role === 'admin'` (admin-controlled), **never**
+  `user_metadata.role` (user-editable → privilege escalation). Enforced by
+  `requireAdmin()` (API) and `requireAdminPage()` (page redirect) in
+  `src/lib/auth-guard.ts`, matching the MCP server's `roleFromToken`.
+- **Secret isolation:** the secret-key client is `import 'server-only'` with a
+  `typeof window` runtime backstop, env-gated (missing key → HTTP 503, never a
+  crash), and never logged or returned to the client.
+
+## Consequences
+
+- Pros:
+  - Secret keys are independently rotatable/revocable without invalidating user
+    sessions — materially better operational security than the `service_role`
+    JWT.
+  - Aligns with Supabase's recommended direction ahead of the end-of-2026
+    legacy deprecation.
+  - One consistent, documented authorization source (`app_metadata.role`).
+- Cons:
+  - A new server secret (`SUPABASE_SECRET_KEY`) must be provisioned in each
+    environment (Vercel). Until then the legacy fallback applies.
+  - Secret keys are not JWTs, so any tooling that assumed a decodable JWT
+    `service_role` token must be updated (none in this repo).
+
+## Rollout / Rollback
+
+- Set `SUPABASE_SECRET_KEY` (from Supabase dashboard → Project Settings → API
+  Keys → Secret keys) in Vercel + local `.env.local`. Admin-user features
+  activate once present.
+- Rollback: the code falls back to `SUPABASE_SERVICE_ROLE_KEY` if the secret key
+  is unset, so reverting is a config change, not a code change.
+- Once verified, delete `SUPABASE_SERVICE_ROLE_KEY` from all environments and
+  drop the fallback branch in `getAdminSupabase()`.
+
+## Related
+
+- Issue #52 (ADR: Auth & API Client decisions) — this ADR covers the auth-key
+  half. The MCP API client (generated `@bryandebaun/mcp-client`, two-factor
+  gateway-key + Supabase-JWT auth in `src/lib/mcp.ts`) is the API-client half.
+- Issue #51 (admin users & invites) — first consumer of the secret key.
+
+Author: Bryan DeBaun

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "next": "16.1.4",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "resend": "^6.14.0"
+    "resend": "^6.14.0",
+    "server-only": "^0.0.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",

--- a/packages/mcp-client/src/api-client.ts
+++ b/packages/mcp-client/src/api-client.ts
@@ -10,6 +10,18 @@
  * ---------------------------------------------------------------
  */
 
+/** Read visibility filter. `all` returns both; `draft`/`all` require admin. */
+export enum ArticleReadStatus {
+  Draft = "draft",
+  Published = "published",
+  All = "all",
+}
+
+export enum ArticleStatus {
+  Draft = "draft",
+  Published = "published",
+}
+
 export enum ItemStatus {
   NOT_STARTED = "NOT_STARTED",
   IN_PROGRESS = "IN_PROGRESS",
@@ -333,6 +345,46 @@ export interface UpdateAuthorRequest {
   website?: string;
 }
 
+export interface Article {
+  /** @format double */
+  id: number;
+  slug: string;
+  title: string;
+  summary?: string | null;
+  body: string;
+  status: ArticleStatus;
+  tags: string[];
+  publishedAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ListArticlesResponse {
+  articles: Article[];
+  /** @format double */
+  total: number;
+}
+
+export interface CreateArticleRequest {
+  slug: string;
+  title: string;
+  body: string;
+  summary?: string;
+  status?: ArticleStatus;
+  tags?: string[];
+  publishedAt?: string;
+}
+
+export interface UpdateArticleRequest {
+  title?: string;
+  body?: string;
+  summary?: string;
+  status?: ArticleStatus;
+  tags?: string[];
+  publishedAt?: string;
+  newSlug?: string;
+}
+
 import type {
   AxiosInstance,
   AxiosRequestConfig,
@@ -527,6 +579,7 @@ export class Api<
      * @tags VideoGames
      * @name ListVideoGames
      * @request GET:/api/videogames
+     * @secure
      */
     listVideoGames: (
       query?: {
@@ -543,6 +596,7 @@ export class Api<
         path: `/api/videogames`,
         method: "GET",
         query: query,
+        secure: true,
         format: "json",
         ...params,
       }),
@@ -575,11 +629,13 @@ export class Api<
      * @tags VideoGames
      * @name GetVideoGame
      * @request GET:/api/videogames/{id}
+     * @secure
      */
     getVideoGame: (id: number, params: RequestParams = {}) =>
       this.request<VideoGame, void>({
         path: `/api/videogames/${id}`,
         method: "GET",
+        secure: true,
         format: "json",
         ...params,
       }),
@@ -635,11 +691,13 @@ export class Api<
      * @tags Spotify
      * @name NowPlaying
      * @request GET:/api/spotify/now-playing
+     * @secure
      */
     nowPlaying: (params: RequestParams = {}) =>
       this.request<PlaybackState, any>({
         path: `/api/spotify/now-playing`,
         method: "GET",
+        secure: true,
         format: "json",
         ...params,
       }),
@@ -650,6 +708,7 @@ export class Api<
      * @tags Spotify
      * @name Liked
      * @request GET:/api/spotify/liked
+     * @secure
      */
     liked: (
       query?: {
@@ -664,6 +723,7 @@ export class Api<
         path: `/api/spotify/liked`,
         method: "GET",
         query: query,
+        secure: true,
         format: "json",
         ...params,
       }),
@@ -674,6 +734,7 @@ export class Api<
      * @tags Spotify
      * @name Playlists
      * @request GET:/api/spotify/playlists
+     * @secure
      */
     playlists: (
       query?: {
@@ -688,6 +749,7 @@ export class Api<
         path: `/api/spotify/playlists`,
         method: "GET",
         query: query,
+        secure: true,
         format: "json",
         ...params,
       }),
@@ -715,6 +777,7 @@ export class Api<
      * @tags Movies
      * @name ListMovies
      * @request GET:/api/movies
+     * @secure
      */
     listMovies: (
       query?: {
@@ -731,6 +794,7 @@ export class Api<
         path: `/api/movies`,
         method: "GET",
         query: query,
+        secure: true,
         format: "json",
         ...params,
       }),
@@ -760,11 +824,13 @@ export class Api<
      * @tags Movies
      * @name GetMovie
      * @request GET:/api/movies/{id}
+     * @secure
      */
     getMovie: (id: number, params: RequestParams = {}) =>
       this.request<Movie, void>({
         path: `/api/movies/${id}`,
         method: "GET",
+        secure: true,
         format: "json",
         ...params,
       }),
@@ -820,6 +886,7 @@ export class Api<
      * @tags ContentCreators
      * @name ListContentCreators
      * @request GET:/api/content-creators
+     * @secure
      */
     listContentCreators: (
       query?: {
@@ -835,6 +902,7 @@ export class Api<
         path: `/api/content-creators`,
         method: "GET",
         query: query,
+        secure: true,
         format: "json",
         ...params,
       }),
@@ -867,11 +935,13 @@ export class Api<
      * @tags ContentCreators
      * @name GetContentCreator
      * @request GET:/api/content-creators/{id}
+     * @secure
      */
     getContentCreator: (id: number, params: RequestParams = {}) =>
       this.request<ContentCreator, void>({
         path: `/api/content-creators/${id}`,
         method: "GET",
+        secure: true,
         format: "json",
         ...params,
       }),
@@ -928,6 +998,7 @@ export class Api<
      * @name ListBooks
      * @summary Get a list of books
      * @request GET:/api/books
+     * @secure
      */
     listBooks: (
       query?: {
@@ -961,6 +1032,7 @@ export class Api<
         path: `/api/books`,
         method: "GET",
         query: query,
+        secure: true,
         format: "json",
         ...params,
       }),
@@ -992,11 +1064,13 @@ export class Api<
      * @name GetBook
      * @summary Get book details by ID
      * @request GET:/api/books/{id}
+     * @secure
      */
     getBook: (id: number, params: RequestParams = {}) =>
       this.request<BookWithAuthors, void>({
         path: `/api/books/${id}`,
         method: "GET",
+        secure: true,
         format: "json",
         ...params,
       }),
@@ -1055,6 +1129,7 @@ export class Api<
      * @name ListAuthors
      * @summary Get a list of authors
      * @request GET:/api/authors
+     * @secure
      */
     listAuthors: (
       query?: {
@@ -1077,6 +1152,7 @@ export class Api<
         path: `/api/authors`,
         method: "GET",
         query: query,
+        secure: true,
         format: "json",
         ...params,
       }),
@@ -1108,11 +1184,13 @@ export class Api<
      * @name GetAuthor
      * @summary Get author details by ID
      * @request GET:/api/authors/{id}
+     * @secure
      */
     getAuthor: (id: number, params: RequestParams = {}) =>
       this.request<AuthorWithBooks, void>({
         path: `/api/authors/${id}`,
         method: "GET",
+        secure: true,
         format: "json",
         ...params,
       }),
@@ -1158,6 +1236,133 @@ export class Api<
         void
       >({
         path: `/api/authors/${id}`,
+        method: "DELETE",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description List articles (published-only unless an admin requests drafts).
+     *
+     * @tags Articles
+     * @name ListArticles
+     * @request GET:/api/articles
+     * @secure
+     */
+    listArticles: (
+      query?: {
+        /** Visibility filter; `draft`/`all` require an admin JWT. */
+        status?: ArticleReadStatus;
+        /** Filter by a single tag */
+        tag?: string;
+        /** Search in title and summary */
+        search?: string;
+        /**
+         * Maximum number of results (default 50)
+         * @format double
+         */
+        limit?: number;
+        /**
+         * Number of results to skip (default 0)
+         * @format double
+         */
+        offset?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<ListArticlesResponse, any>({
+        path: `/api/articles`,
+        method: "GET",
+        query: query,
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Create a new article (admin only).
+     *
+     * @tags Articles
+     * @name CreateArticle
+     * @request POST:/api/articles
+     * @secure
+     */
+    createArticle: (data: CreateArticleRequest, params: RequestParams = {}) =>
+      this.request<Article, void>({
+        path: `/api/articles`,
+        method: "POST",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Get an article by slug (published-only unless an admin requests drafts).
+     *
+     * @tags Articles
+     * @name GetArticle
+     * @request GET:/api/articles/{slug}
+     * @secure
+     */
+    getArticle: (
+      slug: string,
+      query?: {
+        /** Visibility filter; `draft`/`all` require an admin JWT. */
+        status?: ArticleReadStatus;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<Article, void>({
+        path: `/api/articles/${slug}`,
+        method: "GET",
+        query: query,
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Update an article by slug (admin only).
+     *
+     * @tags Articles
+     * @name UpdateArticle
+     * @request PUT:/api/articles/{slug}
+     * @secure
+     */
+    updateArticle: (
+      slug: string,
+      data: UpdateArticleRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<Article, void>({
+        path: `/api/articles/${slug}`,
+        method: "PUT",
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Delete an article by slug (admin only).
+     *
+     * @tags Articles
+     * @name DeleteArticle
+     * @request DELETE:/api/articles/{slug}
+     * @secure
+     */
+    deleteArticle: (slug: string, params: RequestParams = {}) =>
+      this.request<
+        {
+          success: boolean;
+        },
+        void
+      >({
+        path: `/api/articles/${slug}`,
         method: "DELETE",
         secure: true,
         format: "json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       resend:
         specifier: ^6.14.0
         version: 6.14.0
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.16
@@ -4751,6 +4754,9 @@ packages:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -10833,6 +10839,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.3: {}
+
+  server-only@0.0.1: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/src/app/__tests__/admin.page.test.tsx
+++ b/src/app/__tests__/admin.page.test.tsx
@@ -1,46 +1,42 @@
-import { readFileSync } from 'fs';
-import path from 'path';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { describe, it, expect } from 'vitest';
 
+function readAdminPage(): string {
+    const filePath = path.resolve(
+        process.cwd(),
+        'src',
+        'app',
+        'admin',
+        'page.tsx',
+    );
+    return readFileSync(filePath, 'utf8');
+}
+
 describe('Admin page', () => {
-    it('is a server component with server-side auth via Supabase (no "use client")', () => {
-        const filePath = path.resolve(
-            process.cwd(),
-            'src',
-            'app',
-            'admin',
-            'page.tsx',
-        );
-        const src = readFileSync(filePath, 'utf8');
-        expect(src).not.toContain("'use client'");
-        expect(src).toContain('@/lib/supabase/server');
-        expect(src).toContain('redirect');
+    it('is a server component (no "use client")', () => {
+        expect(readAdminPage()).not.toContain("'use client'");
     });
 
     it('renders BooksTable with isAdmin prop and server-fetched books', () => {
-        const filePath = path.resolve(
-            process.cwd(),
-            'src',
-            'app',
-            'admin',
-            'page.tsx',
-        );
-        const src = readFileSync(filePath, 'utf8');
+        const src = readAdminPage();
         expect(src).toContain('BooksTable');
         expect(src).toContain('isAdmin');
         expect(src).toContain('listBooks');
     });
 
-    it('redirects to /login when no user and to / when user is not admin', () => {
-        const filePath = path.resolve(
-            process.cwd(),
-            'src',
-            'app',
-            'admin',
-            'page.tsx',
-        );
-        const src = readFileSync(filePath, 'utf8');
-        expect(src).toContain("redirect('/login')");
-        expect(src).toContain("redirect('/')");
+    it('guards access via the secure app_metadata page guard', () => {
+        const src = readAdminPage();
+        // The page delegates auth to requireAdminPage(), which reads the SECURE
+        // app_metadata.role and redirects (/login when unauthenticated, / when
+        // non-admin). See src/lib/__tests__/auth-guard.test.ts for the behavior.
+        expect(src).toContain('requireAdminPage');
+    });
+
+    it('does NOT use the insecure user-editable user_metadata for authorization', () => {
+        // Reading the role from user_metadata is a privilege-escalation bug:
+        // user_metadata is user-editable. Authorization must use app_metadata
+        // (enforced inside requireAdminPage), never user_metadata here.
+        expect(readAdminPage()).not.toContain('user_metadata');
     });
 });

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,31 +1,22 @@
-import { redirect } from 'next/navigation';
-import { createClient } from '@/lib/supabase/server';
 import BooksTable from '@/components/BooksTable';
+import AdminNav from '@/components/admin/AdminNav';
+import { requireAdminPage } from '@/lib/auth-guard';
 import { listBooks } from '@/lib/services/books';
 
 export const dynamic = 'force-dynamic';
 
 export default async function AdminPage() {
-    const supabase = await createClient();
-    const {
-        data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-        redirect('/login');
-    }
-
-    const role = (user.user_metadata as Record<string, unknown> | undefined)
-        ?.role;
-    if (role !== 'admin') {
-        redirect('/');
-    }
+    // SECURITY: app_metadata-based guard inside requireAdminPage(). Redirects
+    // non-admins. The role is NEVER read from the user-editable metadata bag,
+    // which would be a privilege-escalation bug.
+    await requireAdminPage();
 
     const books = await listBooks();
 
     return (
         <main className="p-6">
             <h1 className="text-2xl font-semibold mb-6">Admin</h1>
+            <AdminNav />
             <section>
                 <h2 className="text-xl font-semibold mb-4">Books</h2>
                 <BooksTable books={books} isAdmin={true} />

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,24 @@
+import AdminNav from '@/components/admin/AdminNav';
+import UsersAdmin from '@/components/admin/UsersAdmin';
+import { requireAdminPage } from '@/lib/auth-guard';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AdminUsersPage() {
+    // SECURITY: app_metadata-based guard (same secure logic as the API
+    // `requireAdmin`). Redirects unauthenticated → /login, non-admin → /.
+    await requireAdminPage();
+
+    return (
+        <main className="p-6">
+            <h1 className="text-2xl font-semibold mb-6">Admin</h1>
+            <AdminNav />
+            <section>
+                <h2 className="text-xl font-semibold mb-4">
+                    Users &amp; Invites
+                </h2>
+                <UsersAdmin />
+            </section>
+        </main>
+    );
+}

--- a/src/app/api/admin/invites/[id]/__tests__/route.test.ts
+++ b/src/app/api/admin/invites/[id]/__tests__/route.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+vi.mock('@/lib/auth-guard', () => ({
+    requireAdmin: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/lib/supabase/admin', () => ({
+    getAdminSupabase: vi.fn(),
+}));
+
+import { requireAdmin } from '@/lib/auth-guard';
+import { getAdminSupabase } from '@/lib/supabase/admin';
+
+const requireAdminMock = requireAdmin as ReturnType<typeof vi.fn>;
+const getAdminSupabaseMock = getAdminSupabase as ReturnType<typeof vi.fn>;
+
+const unauthorized = new Response(JSON.stringify({ error: 'Unauthorized' }), {
+    status: 401,
+});
+const forbidden = new Response(JSON.stringify({ error: 'Forbidden' }), {
+    status: 403,
+});
+
+function makeReq() {
+    return new Request('http://localhost/api/admin/invites/u1', {
+        method: 'DELETE',
+    }) as unknown as NextRequest;
+}
+
+function mockClient(opts: {
+    getUserResult: { data?: unknown; error?: unknown };
+    deleteResult?: { error?: unknown };
+}) {
+    const deleteUser = vi
+        .fn()
+        .mockResolvedValue(opts.deleteResult ?? { error: null });
+    getAdminSupabaseMock.mockReturnValue({
+        ok: true,
+        client: {
+            auth: {
+                admin: {
+                    getUserById: vi.fn().mockResolvedValue(opts.getUserResult),
+                    deleteUser,
+                },
+            },
+        },
+    });
+    return { deleteUser };
+}
+
+describe('DELETE /api/admin/invites/[id]', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        requireAdminMock.mockResolvedValue(null);
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        requireAdminMock.mockResolvedValueOnce(unauthorized);
+        const { DELETE } = await import('../route');
+        const res = await DELETE(makeReq(), { params: { id: 'u1' } });
+        expect((res as Response).status).toBe(401);
+    });
+
+    it('returns 403 when not admin', async () => {
+        requireAdminMock.mockResolvedValueOnce(forbidden);
+        const { DELETE } = await import('../route');
+        const res = await DELETE(makeReq(), { params: { id: 'u1' } });
+        expect((res as Response).status).toBe(403);
+    });
+
+    it('returns 503 when the service-role client is unconfigured', async () => {
+        getAdminSupabaseMock.mockReturnValue({
+            ok: false,
+            reason: 'unconfigured',
+        });
+        const { DELETE } = await import('../route');
+        const res = await DELETE(makeReq(), { params: { id: 'u1' } });
+        expect((res as Response).status).toBe(503);
+    });
+
+    it('revokes a pending invite and returns 204', async () => {
+        const { deleteUser } = mockClient({
+            getUserResult: {
+                data: {
+                    user: {
+                        id: 'u1',
+                        invited_at: '2026-02-01T00:00:00.000Z',
+                    },
+                },
+                error: null,
+            },
+        });
+        const { DELETE } = await import('../route');
+        const res = await DELETE(makeReq(), { params: { id: 'u1' } });
+        expect((res as Response).status).toBe(204);
+        expect(deleteUser).toHaveBeenCalledWith('u1');
+    });
+
+    it('returns 409 and does NOT delete an active user', async () => {
+        const { deleteUser } = mockClient({
+            getUserResult: {
+                data: {
+                    user: {
+                        id: 'u1',
+                        email_confirmed_at: '2026-02-02T00:00:00.000Z',
+                    },
+                },
+                error: null,
+            },
+        });
+        const { DELETE } = await import('../route');
+        const res = await DELETE(makeReq(), { params: { id: 'u1' } });
+        expect((res as Response).status).toBe(409);
+        expect(deleteUser).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when the target user does not exist', async () => {
+        mockClient({
+            getUserResult: { data: { user: null }, error: null },
+        });
+        const { DELETE } = await import('../route');
+        const res = await DELETE(makeReq(), { params: { id: 'missing' } });
+        expect((res as Response).status).toBe(404);
+    });
+});

--- a/src/app/api/admin/invites/[id]/route.ts
+++ b/src/app/api/admin/invites/[id]/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin } from '@/lib/auth-guard';
+import { getAdminSupabase } from '@/lib/supabase/admin';
+import { isPendingInvite } from '@/lib/admin-users';
+
+/**
+ * DELETE /api/admin/invites/[id]
+ *
+ * Revokes a PENDING invite by deleting the not-yet-confirmed user. Gated by
+ * `requireAdmin()` BEFORE any service-role use.
+ *
+ * SAFEGUARD: the target user is re-fetched and its status checked before
+ * deletion. Only `invited`/`unconfirmed` users may be revoked; an `active`
+ * account (e.g. an active admin) is never deleted via this route — it returns
+ * 409 instead.
+ */
+export async function DELETE(
+    _req: NextRequest,
+    context: { params: { id: string } | Promise<{ id: string }> },
+) {
+    const guard = await requireAdmin();
+    if (guard) return guard;
+
+    const admin = getAdminSupabase();
+    if (!admin.ok) {
+        return NextResponse.json(
+            { error: 'Admin user management is not configured.' },
+            { status: 503 },
+        );
+    }
+
+    const params = await context.params;
+    const id = params.id;
+    if (!id) {
+        return NextResponse.json(
+            { error: 'A user id is required.' },
+            { status: 400 },
+        );
+    }
+
+    try {
+        const { data, error } = await admin.client.auth.admin.getUserById(id);
+        if (error || !data?.user) {
+            return NextResponse.json(
+                { error: 'Invite not found.' },
+                { status: 404 },
+            );
+        }
+
+        // Safeguard: never delete an active account through the revoke flow.
+        if (!isPendingInvite(data.user)) {
+            return NextResponse.json(
+                {
+                    error: 'Cannot revoke an active user. Only pending invites can be revoked.',
+                },
+                { status: 409 },
+            );
+        }
+
+        const { error: deleteError } =
+            await admin.client.auth.admin.deleteUser(id);
+        if (deleteError) {
+            console.error('Admin: failed to revoke invite', {
+                name: deleteError.name,
+            });
+            return NextResponse.json(
+                { error: 'Failed to revoke invite.' },
+                { status: 502 },
+            );
+        }
+
+        return new NextResponse(null, { status: 204 });
+    } catch (e) {
+        console.error('Admin: unexpected error revoking invite', e);
+        return NextResponse.json(
+            { error: 'Failed to revoke invite.' },
+            { status: 502 },
+        );
+    }
+}

--- a/src/app/api/admin/invites/__tests__/route.test.ts
+++ b/src/app/api/admin/invites/__tests__/route.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+vi.mock('@/lib/auth-guard', () => ({
+    requireAdmin: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/lib/supabase/admin', () => ({
+    getAdminSupabase: vi.fn(),
+}));
+
+vi.mock('@/lib/email', () => ({
+    sendInviteEmail: vi.fn(),
+}));
+
+import { requireAdmin } from '@/lib/auth-guard';
+import { getAdminSupabase } from '@/lib/supabase/admin';
+import { sendInviteEmail } from '@/lib/email';
+
+const requireAdminMock = requireAdmin as ReturnType<typeof vi.fn>;
+const getAdminSupabaseMock = getAdminSupabase as ReturnType<typeof vi.fn>;
+const sendInviteEmailMock = sendInviteEmail as ReturnType<typeof vi.fn>;
+
+const unauthorized = new Response(JSON.stringify({ error: 'Unauthorized' }), {
+    status: 401,
+});
+const forbidden = new Response(JSON.stringify({ error: 'Forbidden' }), {
+    status: 403,
+});
+
+function makeReq(body: unknown) {
+    return new Request('http://localhost/api/admin/invites', {
+        method: 'POST',
+        body: typeof body === 'string' ? body : JSON.stringify(body),
+        headers: { 'content-type': 'application/json' },
+    }) as unknown as NextRequest;
+}
+
+function mockGenerateLink(result: { data?: unknown; error?: unknown }) {
+    getAdminSupabaseMock.mockReturnValue({
+        ok: true,
+        client: {
+            auth: {
+                admin: {
+                    generateLink: vi.fn().mockResolvedValue(result),
+                },
+            },
+        },
+    });
+}
+
+describe('POST /api/admin/invites', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        requireAdminMock.mockResolvedValue(null);
+        sendInviteEmailMock.mockResolvedValue({ ok: true });
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        requireAdminMock.mockResolvedValueOnce(unauthorized);
+        const { POST } = await import('../route');
+        const res = await POST(makeReq({ email: 'a@b.com' }));
+        expect((res as Response).status).toBe(401);
+    });
+
+    it('returns 403 when not admin', async () => {
+        requireAdminMock.mockResolvedValueOnce(forbidden);
+        const { POST } = await import('../route');
+        const res = await POST(makeReq({ email: 'a@b.com' }));
+        expect((res as Response).status).toBe(403);
+    });
+
+    it('returns 503 when the service-role client is unconfigured', async () => {
+        getAdminSupabaseMock.mockReturnValue({
+            ok: false,
+            reason: 'unconfigured',
+        });
+        const { POST } = await import('../route');
+        const res = await POST(makeReq({ email: 'a@b.com' }));
+        expect((res as Response).status).toBe(503);
+    });
+
+    it('returns 400 for an invalid email', async () => {
+        mockGenerateLink({ data: null, error: null });
+        const { POST } = await import('../route');
+        const res = await POST(makeReq({ email: 'not-an-email' }));
+        expect((res as Response).status).toBe(400);
+    });
+
+    it('creates an invite and sends the email (201, emailSent true)', async () => {
+        mockGenerateLink({
+            data: {
+                properties: { action_link: 'https://invite.example/abc' },
+                user: { id: 'new-user-1' },
+            },
+            error: null,
+        });
+        const { POST } = await import('../route');
+        const res = await POST(makeReq({ email: 'Invitee@Example.com' }));
+        expect((res as Response).status).toBe(201);
+        const json = await (res as Response).json();
+        expect(json).toMatchObject({
+            id: 'new-user-1',
+            email: 'invitee@example.com',
+            emailSent: true,
+            inviteUrl: 'https://invite.example/abc',
+        });
+        expect(sendInviteEmailMock).toHaveBeenCalledWith({
+            email: 'invitee@example.com',
+            inviteUrl: 'https://invite.example/abc',
+        });
+    });
+
+    it('still returns 201 with emailSent false when Resend is unconfigured', async () => {
+        mockGenerateLink({
+            data: {
+                properties: { action_link: 'https://invite.example/xyz' },
+                user: { id: 'new-user-2' },
+            },
+            error: null,
+        });
+        sendInviteEmailMock.mockResolvedValue({
+            ok: false,
+            reason: 'unconfigured',
+        });
+        const { POST } = await import('../route');
+        const res = await POST(makeReq({ email: 'invitee2@example.com' }));
+        expect((res as Response).status).toBe(201);
+        const json = await (res as Response).json();
+        expect(json.emailSent).toBe(false);
+        expect(json.inviteUrl).toBe('https://invite.example/xyz');
+    });
+
+    it('returns 409 when the user already exists', async () => {
+        mockGenerateLink({
+            data: null,
+            error: { name: 'AuthApiError', code: 'email_exists', status: 422 },
+        });
+        const { POST } = await import('../route');
+        const res = await POST(makeReq({ email: 'dupe@example.com' }));
+        expect((res as Response).status).toBe(409);
+        expect(sendInviteEmailMock).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/api/admin/invites/route.ts
+++ b/src/app/api/admin/invites/route.ts
@@ -1,0 +1,132 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin } from '@/lib/auth-guard';
+import { getAdminSupabase } from '@/lib/supabase/admin';
+import { sendInviteEmail } from '@/lib/email';
+import { EMAIL_REGEX } from '@/lib/contact';
+
+/** Maximum accepted request-body size (bytes) — coarse abuse guard. */
+const MAX_BODY_BYTES = 16 * 1024; // 16 KB
+
+interface InvitePayload {
+    email: string;
+}
+
+function asString(value: unknown): string {
+    return typeof value === 'string' ? value : '';
+}
+
+/**
+ * Supabase reports an already-registered email via a 422 with one of these
+ * codes. We map those to a 409 Conflict.
+ */
+function isUserExistsError(error: { status?: number; code?: string }): boolean {
+    if (error.code === 'email_exists' || error.code === 'user_already_exists') {
+        return true;
+    }
+    return error.status === 422;
+}
+
+/**
+ * POST /api/admin/invites
+ *
+ * Body: `{ email }`. Creates an invited user via the service-role client and
+ * generates an invite action link, then sends a branded invite email. Gated by
+ * `requireAdmin()` BEFORE any service-role use.
+ *
+ * Degradation:
+ *  - service-role unconfigured ⇒ 503.
+ *  - Resend unconfigured/failed ⇒ the user is still created; the response sets
+ *    `emailSent: false` and returns `inviteUrl` so the UI can surface it.
+ *  - email already registered ⇒ 409.
+ */
+export async function POST(req: NextRequest) {
+    const guard = await requireAdmin();
+    if (guard) return guard;
+
+    const admin = getAdminSupabase();
+    if (!admin.ok) {
+        return NextResponse.json(
+            { error: 'Admin user management is not configured.' },
+            { status: 503 },
+        );
+    }
+
+    const contentLength = Number(req.headers.get('content-length') ?? '0');
+    if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+        return NextResponse.json(
+            { error: 'Request body too large.' },
+            { status: 413 },
+        );
+    }
+
+    let body: Partial<InvitePayload>;
+    try {
+        body = (await req.json()) as Partial<InvitePayload>;
+    } catch {
+        return NextResponse.json(
+            { error: 'Invalid JSON body.' },
+            { status: 400 },
+        );
+    }
+
+    const email = asString(body.email).trim().toLowerCase();
+    if (!EMAIL_REGEX.test(email)) {
+        return NextResponse.json(
+            {
+                error: 'Validation failed.',
+                fieldErrors: { email: 'A valid email address is required.' },
+            },
+            { status: 400 },
+        );
+    }
+
+    let inviteUrl: string;
+    let userId: string;
+    try {
+        const { data, error } = await admin.client.auth.admin.generateLink({
+            type: 'invite',
+            email,
+        });
+
+        if (error) {
+            if (isUserExistsError(error)) {
+                return NextResponse.json(
+                    { error: 'A user with that email already exists.' },
+                    { status: 409 },
+                );
+            }
+            console.error('Admin: failed to generate invite link', {
+                name: error.name,
+            });
+            return NextResponse.json(
+                { error: 'Failed to create invite.' },
+                { status: 502 },
+            );
+        }
+
+        inviteUrl = data.properties.action_link;
+        userId = data.user.id;
+    } catch (e) {
+        console.error('Admin: unexpected error creating invite', e);
+        return NextResponse.json(
+            { error: 'Failed to create invite.' },
+            { status: 502 },
+        );
+    }
+
+    // User created. Attempt to deliver the invite email; never fail the invite
+    // just because email delivery is unconfigured — surface the link instead.
+    const emailResult = await sendInviteEmail({ email, inviteUrl });
+
+    return NextResponse.json(
+        {
+            id: userId,
+            email,
+            emailSent: emailResult.ok,
+            // Always include the link so an admin can hand it off if email was
+            // not delivered. The link is admin-only (this route is gated).
+            inviteUrl,
+        },
+        { status: 201 },
+    );
+}

--- a/src/app/api/admin/users/__tests__/route.test.ts
+++ b/src/app/api/admin/users/__tests__/route.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth-guard', () => ({
+    requireAdmin: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/lib/supabase/admin', () => ({
+    getAdminSupabase: vi.fn(),
+}));
+
+import { requireAdmin } from '@/lib/auth-guard';
+import { getAdminSupabase } from '@/lib/supabase/admin';
+
+const requireAdminMock = requireAdmin as ReturnType<typeof vi.fn>;
+const getAdminSupabaseMock = getAdminSupabase as ReturnType<typeof vi.fn>;
+
+const unauthorized = new Response(JSON.stringify({ error: 'Unauthorized' }), {
+    status: 401,
+});
+const forbidden = new Response(JSON.stringify({ error: 'Forbidden' }), {
+    status: 403,
+});
+
+function mockListUsers(users: unknown[]) {
+    getAdminSupabaseMock.mockReturnValue({
+        ok: true,
+        client: {
+            auth: {
+                admin: {
+                    listUsers: vi
+                        .fn()
+                        .mockResolvedValue({ data: { users }, error: null }),
+                },
+            },
+        },
+    });
+}
+
+describe('GET /api/admin/users', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        requireAdminMock.mockResolvedValue(null);
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+        requireAdminMock.mockResolvedValueOnce(unauthorized);
+        const { GET } = await import('../route');
+        const res = await GET();
+        expect((res as Response).status).toBe(401);
+    });
+
+    it('returns 403 when not admin', async () => {
+        requireAdminMock.mockResolvedValueOnce(forbidden);
+        const { GET } = await import('../route');
+        const res = await GET();
+        expect((res as Response).status).toBe(403);
+    });
+
+    it('returns 503 when the service-role client is unconfigured', async () => {
+        getAdminSupabaseMock.mockReturnValue({
+            ok: false,
+            reason: 'unconfigured',
+        });
+        const { GET } = await import('../route');
+        const res = await GET();
+        expect((res as Response).status).toBe(503);
+        const json = await (res as Response).json();
+        expect(json.error).toBe('Admin user management is not configured.');
+    });
+
+    it('lists users mapped to AdminUserView on success', async () => {
+        mockListUsers([
+            {
+                id: 'u1',
+                email: 'admin@example.com',
+                app_metadata: { role: 'admin' },
+                user_metadata: {},
+                created_at: '2026-01-01T00:00:00.000Z',
+                email_confirmed_at: '2026-01-02T00:00:00.000Z',
+                last_sign_in_at: '2026-03-01T00:00:00.000Z',
+            },
+            {
+                id: 'u2',
+                email: 'invitee@example.com',
+                app_metadata: {},
+                user_metadata: {},
+                created_at: '2026-02-01T00:00:00.000Z',
+                invited_at: '2026-02-01T00:00:00.000Z',
+            },
+        ]);
+        const { GET } = await import('../route');
+        const res = await GET();
+        expect((res as Response).status).toBe(200);
+        const json = await (res as Response).json();
+        expect(json.users).toHaveLength(2);
+        expect(json.users[0]).toMatchObject({
+            id: 'u1',
+            role: 'admin',
+            status: 'active',
+        });
+        expect(json.users[1]).toMatchObject({
+            id: 'u2',
+            role: null,
+            status: 'invited',
+        });
+    });
+
+    it('returns 502 when listUsers errors', async () => {
+        getAdminSupabaseMock.mockReturnValue({
+            ok: true,
+            client: {
+                auth: {
+                    admin: {
+                        listUsers: vi.fn().mockResolvedValue({
+                            data: null,
+                            error: { name: 'AuthApiError' },
+                        }),
+                    },
+                },
+            },
+        });
+        const { GET } = await import('../route');
+        const res = await GET();
+        expect((res as Response).status).toBe(502);
+    });
+});

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/auth-guard';
+import { getAdminSupabase } from '@/lib/supabase/admin';
+import { toAdminUserView, type AdminUserView } from '@/lib/admin-users';
+
+/**
+ * GET /api/admin/users
+ *
+ * Lists all Supabase auth users (admin-only), mapped to the client-safe
+ * {@link AdminUserView}. Gated by `requireAdmin()` BEFORE any service-role use.
+ * Returns 503 when the service-role client is unconfigured.
+ */
+export async function GET() {
+    const guard = await requireAdmin();
+    if (guard) return guard;
+
+    const admin = getAdminSupabase();
+    if (!admin.ok) {
+        return NextResponse.json(
+            { error: 'Admin user management is not configured.' },
+            { status: 503 },
+        );
+    }
+
+    try {
+        const { data, error } = await admin.client.auth.admin.listUsers();
+        if (error) {
+            console.error('Admin: failed to list users', { name: error.name });
+            return NextResponse.json(
+                { error: 'Failed to list users' },
+                { status: 502 },
+            );
+        }
+
+        const users: AdminUserView[] = data.users.map(toAdminUserView);
+        return NextResponse.json({ users });
+    } catch (e) {
+        console.error('Admin: unexpected error listing users', e);
+        return NextResponse.json(
+            { error: 'Failed to list users' },
+            { status: 502 },
+        );
+    }
+}

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -39,7 +39,18 @@ export async function GET() {
             console.info('auth.me: success', { userId: user.id });
         }
 
-        return NextResponse.json({ user });
+        // Return a minimal projection rather than the raw Supabase user object,
+        // which carries app_metadata/user_metadata/identities/tokens the client
+        // has no need for. `isAdmin` is computed server-side from the SECURE
+        // app_metadata.role (admin-controlled) — never user_metadata, which is
+        // user-editable and must not be trusted for authorization. Mirrors the
+        // role source used by requireAdmin (src/lib/auth-guard.ts).
+        const isAdmin =
+            (user.app_metadata as Record<string, unknown> | undefined)?.role ===
+            'admin';
+        return NextResponse.json({
+            user: { id: user.id, email: user.email, isAdmin },
+        });
     } catch (e) {
         const error = e as Error;
         if (debug) {

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+
+/**
+ * Small admin section navigation linking the admin sub-pages. Rendered at the
+ * top of each admin page so an admin can move between Books and Users.
+ */
+export default function AdminNav() {
+    const linkClass =
+        'text-sm font-medium text-[var(--color-norwegian-700)] hover:underline dark:text-[var(--color-white)]';
+    return (
+        <nav aria-label="Admin sections" className="mb-6">
+            <ul className="flex items-center gap-4">
+                <li>
+                    <Link href="/admin" className={linkClass}>
+                        Books
+                    </Link>
+                </li>
+                <li>
+                    <Link href="/admin/users" className={linkClass}>
+                        Users
+                    </Link>
+                </li>
+            </ul>
+        </nav>
+    );
+}

--- a/src/components/admin/UsersAdmin.tsx
+++ b/src/components/admin/UsersAdmin.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { CellContext, ColumnDef } from '@tanstack/react-table';
+import Table from '@/components/Table';
+import { useAdminUsers } from '@/lib/hooks/useAdminUsers';
+import { EMAIL_REGEX } from '@/lib/contact';
+import type { AdminUserStatus, AdminUserView } from '@/lib/admin-users';
+
+type Props = {
+    /** Server-fetched initial users (optional; the hook can also fetch). */
+    initialUsers?: AdminUserView[];
+};
+
+function StatusPill({ status }: { status: AdminUserStatus }) {
+    const classes =
+        status === 'active'
+            ? 'bg-gradient-to-b from-[var(--color-norwegian-500)] to-[var(--color-norwegian-400)] text-[var(--color-white)] border border-[rgba(0,0,0,0.06)] shadow-sm'
+            : status === 'invited'
+              ? 'bg-gradient-to-b from-[var(--color-norwegian-200)] to-[var(--color-norwegian-300)] text-[var(--color-norwegian-800)] border border-[rgba(0,0,0,0.03)]'
+              : 'bg-[var(--color-norwegian-50)] text-[var(--color-norwegian-700)] dark:bg-[var(--color-norwegian-100-dark)] dark:text-[var(--color-norwegian-300-dark)]';
+    return (
+        <span
+            className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${classes}`}
+        >
+            {status}
+        </span>
+    );
+}
+
+function formatDate(value: string | null): string {
+    if (!value) return '—';
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? '—' : d.toLocaleDateString();
+}
+
+export default function UsersAdmin({ initialUsers }: Props) {
+    const { users, isError, error, inviteMutation, revokeMutation } =
+        useAdminUsers(initialUsers);
+
+    const [email, setEmail] = useState('');
+    const [formError, setFormError] = useState<string | null>(null);
+    const [inviteLink, setInviteLink] = useState<string | null>(null);
+    const [notice, setNotice] = useState<string | null>(null);
+
+    const handleInvite = (e: React.FormEvent) => {
+        e.preventDefault();
+        setFormError(null);
+        setInviteLink(null);
+        setNotice(null);
+
+        const value = email.trim().toLowerCase();
+        if (!EMAIL_REGEX.test(value)) {
+            setFormError('A valid email address is required.');
+            return;
+        }
+
+        inviteMutation.mutate(value, {
+            onSuccess: (result) => {
+                setEmail('');
+                if (result.emailSent) {
+                    setNotice(`Invitation emailed to ${result.email}.`);
+                } else {
+                    setNotice(
+                        `User ${result.email} invited, but the email could not be sent. Share the invite link below.`,
+                    );
+                    setInviteLink(result.inviteUrl);
+                }
+            },
+            onError: (err) => {
+                setFormError((err as Error).message);
+            },
+        });
+    };
+
+    const handleRevoke = (user: AdminUserView) => {
+        if (
+            !window.confirm(
+                `Revoke the pending invite for ${user.email ?? user.id}? This cannot be undone.`,
+            )
+        ) {
+            return;
+        }
+        setNotice(null);
+        setFormError(null);
+        revokeMutation.mutate(user.id, {
+            onError: (err) => {
+                setFormError((err as Error).message);
+            },
+        });
+    };
+
+    const columns = useMemo<ColumnDef<AdminUserView, unknown>[]>(
+        () => [
+            {
+                id: 'email',
+                header: 'Email',
+                meta: {
+                    headerClassName: 'text-left',
+                    cellClassName: 'text-left',
+                },
+                cell: (info: CellContext<AdminUserView, unknown>) =>
+                    info.row.original.email ?? '—',
+            },
+            {
+                id: 'role',
+                header: 'Role',
+                cell: (info: CellContext<AdminUserView, unknown>) =>
+                    info.row.original.role ?? '—',
+            },
+            {
+                id: 'status',
+                header: 'Status',
+                cell: (info: CellContext<AdminUserView, unknown>) => (
+                    <StatusPill status={info.row.original.status} />
+                ),
+            },
+            {
+                id: 'createdAt',
+                header: 'Created',
+                cell: (info: CellContext<AdminUserView, unknown>) =>
+                    formatDate(info.row.original.createdAt),
+            },
+            {
+                id: 'lastSignInAt',
+                header: 'Last sign-in',
+                cell: (info: CellContext<AdminUserView, unknown>) =>
+                    formatDate(info.row.original.lastSignInAt),
+            },
+            {
+                id: 'actions',
+                header: 'Actions',
+                meta: {
+                    headerClassName: 'w-28 text-right',
+                    cellClassName: 'w-28 text-right',
+                },
+                cell: (info: CellContext<AdminUserView, unknown>) => {
+                    const user = info.row.original;
+                    if (user.status === 'active') {
+                        return (
+                            <span className="text-xs text-[var(--color-norwegian-500)]">
+                                —
+                            </span>
+                        );
+                    }
+                    return (
+                        <button
+                            type="button"
+                            className="inline-flex items-center justify-center rounded-md px-2 py-1 text-xs text-[var(--color-white)] cursor-pointer bg-gradient-to-b from-red-600 to-red-500 hover:from-red-500 hover:to-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-fjord-600)]"
+                            onClick={() => handleRevoke(user)}
+                            disabled={revokeMutation.isPending}
+                        >
+                            Revoke
+                        </button>
+                    );
+                },
+            },
+        ],
+        // handleRevoke is stable enough for this UI; revoke pending state drives disabled
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [revokeMutation.isPending],
+    );
+
+    return (
+        <div>
+            <form
+                onSubmit={handleInvite}
+                className="mb-6 flex flex-wrap items-end gap-3"
+                aria-label="Invite user"
+            >
+                <div className="flex flex-col">
+                    <label htmlFor="invite-email" className="text-sm mb-1">
+                        Invite user by email
+                    </label>
+                    <input
+                        id="invite-email"
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="person@example.com"
+                        className="rounded-md border border-[var(--tw-prose-td-borders)] bg-[var(--background)] px-3 py-2 text-sm"
+                        autoComplete="off"
+                    />
+                </div>
+                <button
+                    type="submit"
+                    className="btn btn--primary"
+                    disabled={inviteMutation.isPending}
+                >
+                    {inviteMutation.isPending ? 'Inviting…' : 'Invite'}
+                </button>
+            </form>
+
+            {formError ? (
+                <p role="alert" className="mb-4 text-sm text-red-600">
+                    {formError}
+                </p>
+            ) : null}
+            {notice ? (
+                <p className="mb-4 text-sm text-[var(--color-norwegian-700)] dark:text-[var(--color-white)]">
+                    {notice}
+                </p>
+            ) : null}
+            {inviteLink ? (
+                <p className="mb-4 text-sm break-all">
+                    Invite link:{' '}
+                    <a href={inviteLink} className="underline">
+                        {inviteLink}
+                    </a>
+                </p>
+            ) : null}
+            {isError ? (
+                <p role="alert" className="mb-4 text-sm text-red-600">
+                    {error?.message ?? 'Failed to load users.'}
+                </p>
+            ) : null}
+
+            <Table
+                data={users}
+                columns={columns}
+                className="overflow-x-auto rounded-lg border border-[var(--tw-prose-td-borders)] dark:border-[var(--tw-prose-invert-td-borders)] bg-[var(--background)] shadow-sm ring-1 ring-[var(--tw-prose-td-borders)]"
+                caption="Admin users list"
+            />
+        </div>
+    );
+}

--- a/src/lib/__tests__/admin-users.test.ts
+++ b/src/lib/__tests__/admin-users.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import type { User } from '@supabase/supabase-js';
+import {
+    isPendingInvite,
+    roleFromUser,
+    statusFromUser,
+    toAdminUserView,
+} from '@/lib/admin-users';
+
+function makeUser(overrides: Partial<User> = {}): User {
+    return {
+        id: 'user-1',
+        app_metadata: {},
+        user_metadata: {},
+        aud: 'authenticated',
+        created_at: '2026-01-01T00:00:00.000Z',
+        ...overrides,
+    } as User;
+}
+
+describe('roleFromUser', () => {
+    it('returns admin from app_metadata.role', () => {
+        expect(
+            roleFromUser(makeUser({ app_metadata: { role: 'admin' } })),
+        ).toBe('admin');
+    });
+
+    it('returns user from app_metadata.role', () => {
+        expect(roleFromUser(makeUser({ app_metadata: { role: 'user' } }))).toBe(
+            'user',
+        );
+    });
+
+    it('returns null when no role is set', () => {
+        expect(roleFromUser(makeUser({ app_metadata: {} }))).toBeNull();
+    });
+
+    it('returns null for an unknown role value', () => {
+        expect(
+            roleFromUser(makeUser({ app_metadata: { role: 'superuser' } })),
+        ).toBeNull();
+    });
+
+    it('NEVER reads role from user-editable user_metadata (privilege-escalation guard)', () => {
+        const user = makeUser({
+            app_metadata: {},
+            user_metadata: { role: 'admin' },
+        });
+        expect(roleFromUser(user)).toBeNull();
+    });
+});
+
+describe('statusFromUser', () => {
+    it('returns invited when invited_at is set and email is unconfirmed', () => {
+        expect(
+            statusFromUser(
+                makeUser({ invited_at: '2026-02-01T00:00:00.000Z' }),
+            ),
+        ).toBe('invited');
+    });
+
+    it('returns unconfirmed when never invited and never confirmed', () => {
+        expect(statusFromUser(makeUser())).toBe('unconfirmed');
+    });
+
+    it('returns active when email is confirmed (even if previously invited)', () => {
+        expect(
+            statusFromUser(
+                makeUser({
+                    invited_at: '2026-02-01T00:00:00.000Z',
+                    email_confirmed_at: '2026-02-02T00:00:00.000Z',
+                }),
+            ),
+        ).toBe('active');
+    });
+
+    it('returns active when confirmed without an invite', () => {
+        expect(
+            statusFromUser(
+                makeUser({ email_confirmed_at: '2026-02-02T00:00:00.000Z' }),
+            ),
+        ).toBe('active');
+    });
+});
+
+describe('isPendingInvite', () => {
+    it('is true for invited and unconfirmed users', () => {
+        expect(
+            isPendingInvite(
+                makeUser({ invited_at: '2026-02-01T00:00:00.000Z' }),
+            ),
+        ).toBe(true);
+        expect(isPendingInvite(makeUser())).toBe(true);
+    });
+
+    it('is false for an active user (cannot be revoked)', () => {
+        expect(
+            isPendingInvite(
+                makeUser({ email_confirmed_at: '2026-02-02T00:00:00.000Z' }),
+            ),
+        ).toBe(false);
+    });
+});
+
+describe('toAdminUserView', () => {
+    it('maps a confirmed admin to an active view', () => {
+        const view = toAdminUserView(
+            makeUser({
+                id: 'abc',
+                email: 'admin@example.com',
+                app_metadata: { role: 'admin' },
+                email_confirmed_at: '2026-02-02T00:00:00.000Z',
+                last_sign_in_at: '2026-03-01T00:00:00.000Z',
+            }),
+        );
+        expect(view).toEqual({
+            id: 'abc',
+            email: 'admin@example.com',
+            role: 'admin',
+            status: 'active',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            lastSignInAt: '2026-03-01T00:00:00.000Z',
+            invitedAt: null,
+        });
+    });
+
+    it('maps a pending invite with no role/sign-in to nulls', () => {
+        const view = toAdminUserView(
+            makeUser({
+                id: 'def',
+                email: 'invitee@example.com',
+                invited_at: '2026-02-01T00:00:00.000Z',
+            }),
+        );
+        expect(view.role).toBeNull();
+        expect(view.status).toBe('invited');
+        expect(view.lastSignInAt).toBeNull();
+        expect(view.invitedAt).toBe('2026-02-01T00:00:00.000Z');
+    });
+
+    it('handles a missing email gracefully', () => {
+        expect(
+            toAdminUserView(makeUser({ email: undefined })).email,
+        ).toBeNull();
+    });
+});

--- a/src/lib/__tests__/auth-guard.test.ts
+++ b/src/lib/__tests__/auth-guard.test.ts
@@ -4,8 +4,16 @@ vi.mock('@/lib/supabase/server', () => ({
     createClient: vi.fn(),
 }));
 
+// `redirect` throws a control-flow signal in Next; mock it to throw a tagged
+// error we can assert on (capturing the redirect target).
+vi.mock('next/navigation', () => ({
+    redirect: vi.fn((url: string) => {
+        throw new Error(`REDIRECT:${url}`);
+    }),
+}));
+
 import { createClient } from '@/lib/supabase/server';
-import { requireAdmin } from '@/lib/auth-guard';
+import { requireAdmin, requireAdminPage } from '@/lib/auth-guard';
 
 describe('requireAdmin', () => {
     beforeEach(() => vi.clearAllMocks());
@@ -89,5 +97,59 @@ describe('requireAdmin', () => {
         const result = await requireAdmin();
 
         expect(result).toBeNull();
+    });
+});
+
+describe('requireAdminPage', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('redirects to /login when no user is authenticated', async () => {
+        (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+            auth: {
+                getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+            },
+        });
+
+        await expect(requireAdminPage()).rejects.toThrow('REDIRECT:/login');
+    });
+
+    it('redirects to / when the user is not an admin', async () => {
+        (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+            auth: {
+                getUser: vi.fn().mockResolvedValue({
+                    data: { user: { app_metadata: { role: 'viewer' } } },
+                }),
+            },
+        });
+
+        await expect(requireAdminPage()).rejects.toThrow('REDIRECT:/');
+    });
+
+    it('redirects to / and does NOT trust user-editable user_metadata', async () => {
+        (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+            auth: {
+                getUser: vi.fn().mockResolvedValue({
+                    data: {
+                        user: {
+                            user_metadata: { role: 'admin' },
+                            app_metadata: {},
+                        },
+                    },
+                }),
+            },
+        });
+
+        await expect(requireAdminPage()).rejects.toThrow('REDIRECT:/');
+    });
+
+    it('returns the user when they are an admin via app_metadata', async () => {
+        const user = { id: 'admin-1', app_metadata: { role: 'admin' } };
+        (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+            auth: {
+                getUser: vi.fn().mockResolvedValue({ data: { user } }),
+            },
+        });
+
+        await expect(requireAdminPage()).resolves.toBe(user);
     });
 });

--- a/src/lib/admin-users.ts
+++ b/src/lib/admin-users.ts
@@ -1,0 +1,92 @@
+import type { User } from '@supabase/supabase-js';
+
+/**
+ * RBAC role as stored in the SECURE `app_metadata.role`. `null` means no role
+ * has been assigned (a normal, non-admin account).
+ */
+export type AdminUserRole = 'admin' | 'user' | null;
+
+/**
+ * Derived account status for the admin users list:
+ *  - `invited`     — invite issued (`invited_at` set) but not yet confirmed.
+ *  - `unconfirmed` — created but email never confirmed (and not via invite).
+ *  - `active`      — email confirmed; a fully onboarded account.
+ */
+export type AdminUserStatus = 'active' | 'invited' | 'unconfirmed';
+
+/**
+ * Flattened, client-safe view of a Supabase auth user for the admin UI. Contains
+ * only non-sensitive fields (no tokens, no raw metadata).
+ */
+export interface AdminUserView {
+    id: string;
+    email: string | null;
+    role: AdminUserRole;
+    status: AdminUserStatus;
+    createdAt: string | null;
+    lastSignInAt: string | null;
+    invitedAt: string | null;
+}
+
+/**
+ * Map the role from a user's `app_metadata`. Only the two known RBAC roles are
+ * surfaced; anything else (including absent) becomes `null`.
+ *
+ * SECURITY: reads `app_metadata` (admin-controlled), never the user-editable
+ * `user_metadata`.
+ */
+export function roleFromUser(user: Pick<User, 'app_metadata'>): AdminUserRole {
+    const raw = (user.app_metadata as Record<string, unknown> | undefined)
+        ?.role;
+    if (raw === 'admin') return 'admin';
+    if (raw === 'user') return 'user';
+    return null;
+}
+
+/**
+ * Derive the account status from confirmation/invite timestamps.
+ *
+ * Rules (in order):
+ *  1. `invited_at` set AND not yet confirmed ⇒ `invited`.
+ *  2. otherwise not confirmed ⇒ `unconfirmed`.
+ *  3. otherwise ⇒ `active`.
+ */
+export function statusFromUser(
+    user: Pick<User, 'invited_at' | 'email_confirmed_at'>,
+): AdminUserStatus {
+    const confirmed = Boolean(user.email_confirmed_at);
+    if (!confirmed && user.invited_at) {
+        return 'invited';
+    }
+    if (!confirmed) {
+        return 'unconfirmed';
+    }
+    return 'active';
+}
+
+/**
+ * True when a user is a still-pending invite/unconfirmed account that is safe to
+ * revoke (delete). An `active` account must never be deleted via the invite
+ * revoke flow.
+ */
+export function isPendingInvite(
+    user: Pick<User, 'invited_at' | 'email_confirmed_at'>,
+): boolean {
+    return statusFromUser(user) !== 'active';
+}
+
+/**
+ * Map a raw Supabase `User` to the flattened, client-safe {@link AdminUserView}.
+ * Pure and unit-testable; performs no I/O.
+ */
+export function toAdminUserView(user: User): AdminUserView {
+    return {
+        id: user.id,
+        email: user.email ?? null,
+        role: roleFromUser(user),
+        status: statusFromUser(user),
+        createdAt: user.created_at ?? null,
+        lastSignInAt: user.last_sign_in_at ?? null,
+        invitedAt: user.invited_at ?? null,
+    };
+}

--- a/src/lib/auth-guard.ts
+++ b/src/lib/auth-guard.ts
@@ -1,5 +1,20 @@
 import { NextResponse } from 'next/server';
+import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
+
+/**
+ * Read the RBAC role from a Supabase user's `app_metadata`.
+ *
+ * `app_metadata` is admin-controlled and is the SECURE location for authorization.
+ * `user_metadata` is user-editable, so trusting it for authorization would be a
+ * privilege-escalation risk. This mirrors the MCP server's `roleFromToken`
+ * (src/auth/jwt.ts), keeping both repos aligned on one source of truth.
+ */
+function roleFromAppMetadata(
+    appMetadata: Record<string, unknown> | undefined,
+): unknown {
+    return appMetadata?.role;
+}
 
 /**
  * Returns a 401/403 NextResponse if the caller is not an authenticated admin,
@@ -19,16 +34,48 @@ export async function requireAdmin(): Promise<NextResponse | null> {
         return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    // Read the role from app_metadata, NOT user_metadata. user_metadata is
-    // user-editable, so trusting it for authorization is a privilege-escalation
-    // risk. app_metadata is admin-controlled and is the same secure RBAC location
-    // the MCP server checks (src/auth/jwt.ts `roleFromToken`), keeping both repos
-    // aligned on one source of truth.
-    const role = (user.app_metadata as Record<string, unknown> | undefined)
-        ?.role;
+    const role = roleFromAppMetadata(
+        user.app_metadata as Record<string, unknown> | undefined,
+    );
     if (role !== 'admin') {
         return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
     return null;
+}
+
+/**
+ * Page-oriented admin guard: the `redirect()` analog of {@link requireAdmin}.
+ *
+ * Reads the role from the SECURE `app_metadata.role` (never user-editable
+ * `user_metadata`). Use this at the top of a server-component admin page:
+ *
+ *   export default async function AdminPage() {
+ *     await requireAdminPage();
+ *     // ...render admin UI
+ *   }
+ *
+ * Redirects unauthenticated callers to `/login` and authenticated-but-non-admin
+ * callers to `/`. Both throw Next's redirect signal, so code after the call only
+ * runs for an authenticated admin. Returns the authenticated admin user so the
+ * page can use it without re-fetching.
+ */
+export async function requireAdminPage() {
+    const supabase = await createClient();
+    const {
+        data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+        redirect('/login');
+    }
+
+    const role = roleFromAppMetadata(
+        user.app_metadata as Record<string, unknown> | undefined,
+    );
+    if (role !== 'admin') {
+        redirect('/');
+    }
+
+    return user;
 }

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -37,18 +37,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             const payload = await res.json();
             const u = payload?.user;
             if (isUser(u)) {
-                // Map Supabase user to our User type
-                // Check user_metadata for admin role
-                const isAdmin =
-                    (
-                        u as Record<string, unknown> & {
-                            user_metadata?: { role?: string };
-                        }
-                    ).user_metadata?.role === 'admin';
+                // `isAdmin` is computed server-side from app_metadata by
+                // /api/auth/me — trust that, never re-derive from client-visible
+                // metadata (user_metadata is user-editable).
                 setUser({
                     id: u.id,
                     email: u.email,
-                    isAdmin,
+                    isAdmin: u.isAdmin === true,
                 });
             } else {
                 setUser(null);

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -130,3 +130,107 @@ export async function sendContactEmail(
         return { ok: false, reason: 'send_failed', detail: error.message };
     }
 }
+
+/** Input for a branded admin invite email. */
+export interface InviteEmailInput {
+    /** Recipient email address (the invited user). */
+    email: string;
+    /** Supabase action link the recipient clicks to accept the invite. */
+    inviteUrl: string;
+}
+
+/**
+ * Resend configuration for the invite sender. The "to" address is the recipient
+ * (passed per-call), so only the API key and a verified "from" address are read
+ * from the environment.
+ */
+interface InviteResendConfig {
+    apiKey: string;
+    fromEmail: string;
+}
+
+/**
+ * Read the invite-email config from the environment. Reuses `RESEND_API_KEY`
+ * and `CONTACT_FROM_EMAIL` (the verified sender) so no new secret is required.
+ * Returns `null` when anything is missing so callers can degrade gracefully.
+ */
+function readInviteResendConfig(): InviteResendConfig | null {
+    const apiKey = process.env.RESEND_API_KEY?.trim();
+    const fromEmail = process.env.CONTACT_FROM_EMAIL?.trim();
+
+    if (!apiKey || !fromEmail) {
+        return null;
+    }
+
+    return { apiKey, fromEmail };
+}
+
+/**
+ * Send a branded admin invite email via Resend. Same env-gated, lazy, secret-safe
+ * pattern as {@link sendContactEmail}: when Resend is not configured this returns
+ * `{ ok: false, reason: 'unconfigured' }` so the caller can still surface the
+ * raw invite link as a fallback rather than failing the invite outright.
+ *
+ * The `inviteUrl` is a trusted Supabase action link, but it is still HTML-escaped
+ * before interpolation as defense-in-depth.
+ */
+export async function sendInviteEmail(
+    input: InviteEmailInput,
+): Promise<SendContactResult> {
+    const config = readInviteResendConfig();
+    if (!config) {
+        console.warn(
+            'email.sendInviteEmail: Resend is not configured (missing RESEND_API_KEY / CONTACT_FROM_EMAIL); skipping send.',
+        );
+        return { ok: false, reason: 'unconfigured' };
+    }
+
+    const email = sanitizeHeaderValue(input.email);
+    const inviteUrl = input.inviteUrl;
+    const safeUrl = escapeHtml(inviteUrl);
+
+    try {
+        const resend = new Resend(config.apiKey);
+
+        const { error } = await resend.emails.send({
+            from: config.fromEmail,
+            to: email,
+            subject: "You're invited to bryandebaun.dev",
+            text: [
+                "You've been invited to bryandebaun.dev.",
+                '',
+                'Accept your invitation by opening the link below:',
+                inviteUrl,
+            ].join('\n'),
+            html: [
+                '<div>',
+                "<p>You've been invited to <strong>bryandebaun.dev</strong>.</p>",
+                '<p>Accept your invitation by clicking the link below:</p>',
+                `<p><a href="${safeUrl}">Accept invitation</a></p>`,
+                '<hr />',
+                '<p style="color:#666;font-size:12px">If the button does not work, copy and paste this URL into your browser:</p>',
+                `<p style="word-break:break-all;font-size:12px">${safeUrl}</p>`,
+                '</div>',
+            ].join(''),
+        });
+
+        if (error) {
+            console.error('email.sendInviteEmail: Resend send failed', {
+                name: error.name,
+            });
+            return {
+                ok: false,
+                reason: 'send_failed',
+                detail: error.name,
+            };
+        }
+
+        return { ok: true };
+    } catch (e) {
+        const error = e as Error;
+        console.error('email.sendInviteEmail: unexpected send error', {
+            message: error.message,
+        });
+        return { ok: false, reason: 'send_failed', detail: error.message };
+    }
+}

--- a/src/lib/hooks/useAdminUsers.ts
+++ b/src/lib/hooks/useAdminUsers.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { AdminUserView } from '@/lib/admin-users';
+import * as repo from '@/lib/repositories/usersRepository';
+
+const USERS_KEY = ['admin-users'];
+
+/**
+ * TanStack Query hook powering the admin users/invites UI. Fetches the users
+ * list and exposes invite-create and invite-revoke mutations that invalidate
+ * the list on settle (refresh after mutation).
+ */
+export function useAdminUsers(initialUsers?: AdminUserView[]) {
+    const qc = useQueryClient();
+
+    const usersQuery = useQuery({
+        queryKey: USERS_KEY,
+        queryFn: repo.listAdminUsers,
+        initialData: initialUsers,
+    });
+
+    const inviteMutation = useMutation({
+        mutationFn: (email: string) => repo.createInvite(email),
+        onSettled: () => {
+            qc.invalidateQueries({ queryKey: USERS_KEY });
+        },
+    });
+
+    const revokeMutation = useMutation({
+        mutationFn: (id: string) => repo.revokeInvite(id),
+        onSettled: () => {
+            qc.invalidateQueries({ queryKey: USERS_KEY });
+        },
+    });
+
+    return {
+        users: usersQuery.data ?? [],
+        isLoading: usersQuery.isLoading,
+        isError: usersQuery.isError,
+        error: usersQuery.error as Error | null,
+        refetch: usersQuery.refetch,
+        inviteMutation,
+        revokeMutation,
+    };
+}

--- a/src/lib/repositories/usersRepository.ts
+++ b/src/lib/repositories/usersRepository.ts
@@ -1,0 +1,59 @@
+import type { AdminUserView } from '@/lib/admin-users';
+
+/**
+ * Client-side repository for admin user/invite operations. Talks to the admin
+ * API routes (which enforce auth + use the server-only service-role client).
+ */
+
+export interface InviteResult {
+    id: string;
+    email: string;
+    emailSent: boolean;
+    inviteUrl: string;
+}
+
+/** Fetch the admin users list. */
+export async function listAdminUsers(): Promise<AdminUserView[]> {
+    const res = await fetch('/api/admin/users');
+    if (!res.ok) {
+        if (res.status === 503) {
+            throw new Error('Admin user management is not configured.');
+        }
+        throw new Error(`Failed to fetch users: ${res.status}`);
+    }
+    const data = (await res.json()) as { users: AdminUserView[] };
+    return data.users ?? [];
+}
+
+/** Create an invite for the given email. */
+export async function createInvite(email: string): Promise<InviteResult> {
+    const res = await fetch('/api/admin/invites', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email }),
+    });
+    const data = (await res.json().catch(() => null)) as
+        | (InviteResult & { error?: string })
+        | { error?: string }
+        | null;
+    if (!res.ok) {
+        const message =
+            (data && 'error' in data && data.error) ||
+            `Failed to create invite: ${res.status}`;
+        throw new Error(message);
+    }
+    return data as InviteResult;
+}
+
+/** Revoke a pending invite by user id. */
+export async function revokeInvite(id: string): Promise<void> {
+    const res = await fetch(`/api/admin/invites/${id}`, { method: 'DELETE' });
+    if (!res.ok && res.status !== 204) {
+        const data = (await res.json().catch(() => null)) as {
+            error?: string;
+        } | null;
+        throw new Error(
+            data?.error ?? `Failed to revoke invite: ${res.status}`,
+        );
+    }
+}

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -3,21 +3,30 @@ import 'server-only';
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 /**
- * Server-only Supabase client constructed with the SERVICE ROLE key.
+ * Server-only Supabase client constructed with a privileged SECRET key.
  *
- * The service-role key bypasses Row Level Security and can perform privileged
+ * This key bypasses Row Level Security and can perform privileged
  * `auth.admin.*` operations (listing users, generating invite links, deleting
  * users). It MUST NEVER reach the browser:
  *  - `import 'server-only'` makes any client-bundle import a build error.
  *  - As a defensive runtime backstop we also throw if `window` is defined.
  *
  * The client is created lazily and the configuration is env-gated, so the app
- * builds and runs without `SUPABASE_SERVICE_ROLE_KEY`. Admin-user features then
- * report "not configured" (HTTP 503) instead of crashing.
+ * builds and runs without the key. Admin-user features then report
+ * "not configured" (HTTP 503) instead of crashing.
+ *
+ * Key choice (see docs/adr/0003-supabase-api-keys.md): we use the MODERN
+ * Supabase **secret key** (`sb_secret_*`), which replaces the legacy
+ * `service_role` JWT. Supabase recommends switching off the JWT-based
+ * `anon`/`service_role` keys (they keep working only until end of 2026). We
+ * read `SUPABASE_SECRET_KEY` first and fall back to the legacy
+ * `SUPABASE_SERVICE_ROLE_KEY` so existing deployments keep working during the
+ * transition.
  *
  * Required env:
  *  - `NEXT_PUBLIC_SUPABASE_URL` (already used by the public clients)
- *  - `SUPABASE_SERVICE_ROLE_KEY` (server-only; Supabase dashboard → API settings)
+ *  - `SUPABASE_SECRET_KEY` (server-only; Supabase dashboard → Project Settings →
+ *    API Keys → Secret keys). Legacy fallback: `SUPABASE_SERVICE_ROLE_KEY`.
  */
 
 // Defensive backstop in case a future refactor strips the `server-only` import.
@@ -31,8 +40,8 @@ if (typeof window !== 'undefined') {
  * Discriminated result of attempting to obtain the service-role client.
  *
  * - `ok: true` — a configured client is available.
- * - `reason: 'unconfigured'` — `SUPABASE_SERVICE_ROLE_KEY` (or the Supabase URL)
- *   is missing. Callers should map this to a 503 ("not configured").
+ * - `reason: 'unconfigured'` — the secret key (or the Supabase URL) is missing.
+ *   Callers should map this to a 503 ("not configured").
  */
 export type AdminSupabaseResult =
     | { ok: true; client: SupabaseClient }
@@ -51,13 +60,17 @@ export function getAdminSupabase(): AdminSupabaseResult {
     }
 
     const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
-    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
+    // Prefer the modern secret key; fall back to the legacy service_role key
+    // during migration. See docs/adr/0003-supabase-api-keys.md.
+    const secretKey =
+        process.env.SUPABASE_SECRET_KEY?.trim() ||
+        process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
 
-    if (!url || !serviceRoleKey) {
+    if (!url || !secretKey) {
         return { ok: false, reason: 'unconfigured' };
     }
 
-    cachedClient = createClient(url, serviceRoleKey, {
+    cachedClient = createClient(url, secretKey, {
         auth: {
             autoRefreshToken: false,
             persistSession: false,

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,0 +1,68 @@
+import 'server-only';
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Server-only Supabase client constructed with the SERVICE ROLE key.
+ *
+ * The service-role key bypasses Row Level Security and can perform privileged
+ * `auth.admin.*` operations (listing users, generating invite links, deleting
+ * users). It MUST NEVER reach the browser:
+ *  - `import 'server-only'` makes any client-bundle import a build error.
+ *  - As a defensive runtime backstop we also throw if `window` is defined.
+ *
+ * The client is created lazily and the configuration is env-gated, so the app
+ * builds and runs without `SUPABASE_SERVICE_ROLE_KEY`. Admin-user features then
+ * report "not configured" (HTTP 503) instead of crashing.
+ *
+ * Required env:
+ *  - `NEXT_PUBLIC_SUPABASE_URL` (already used by the public clients)
+ *  - `SUPABASE_SERVICE_ROLE_KEY` (server-only; Supabase dashboard → API settings)
+ */
+
+// Defensive backstop in case a future refactor strips the `server-only` import.
+if (typeof window !== 'undefined') {
+    throw new Error(
+        'src/lib/supabase/admin.ts must never be imported in the browser.',
+    );
+}
+
+/**
+ * Discriminated result of attempting to obtain the service-role client.
+ *
+ * - `ok: true` — a configured client is available.
+ * - `reason: 'unconfigured'` — `SUPABASE_SERVICE_ROLE_KEY` (or the Supabase URL)
+ *   is missing. Callers should map this to a 503 ("not configured").
+ */
+export type AdminSupabaseResult =
+    | { ok: true; client: SupabaseClient }
+    | { ok: false; reason: 'unconfigured' };
+
+let cachedClient: SupabaseClient | null = null;
+
+/**
+ * Return the service-role Supabase client, or an `unconfigured` result when the
+ * required env vars are absent. Never throws for missing configuration. Secrets
+ * are never logged.
+ */
+export function getAdminSupabase(): AdminSupabaseResult {
+    if (cachedClient) {
+        return { ok: true, client: cachedClient };
+    }
+
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
+
+    if (!url || !serviceRoleKey) {
+        return { ok: false, reason: 'unconfigured' };
+    }
+
+    cachedClient = createClient(url, serviceRoleKey, {
+        auth: {
+            autoRefreshToken: false,
+            persistSession: false,
+        },
+    });
+
+    return { ok: true, client: cachedClient };
+}


### PR DESCRIPTION
## Summary

Implements the **Admin Users & Invites** feature (#51): a protected admin users listing with roles + statuses, and create/revoke email invites. Security-reviewed (verdict: ship). Off clean `main`.

## Security fix (the headline)

`src/app/admin/page.tsx` authorized via **`user_metadata.role`** — which is *user-editable*, a privilege-escalation hole and inconsistent with the API's `requireAdmin()`. Fixed by adding **`requireAdminPage()`** (the redirect analog of `requireAdmin`) that reads the secure **`app_metadata.role`**. Also hardened two adjacent spots the security review flagged (same `user_metadata` anti-pattern):
- `/api/auth/me` now returns a minimal `{ id, email, isAdmin }` projection (isAdmin computed server-side from `app_metadata`) instead of the raw Supabase user object.
- `src/lib/auth.tsx` consumes that server `isAdmin` instead of re-deriving from client-visible metadata.

## Feature

- **Service-role client** (`src/lib/supabase/admin.ts`) — `import 'server-only'` + `typeof window` backstop; env-gated (returns typed "unconfigured", never crashes the build).
- **API routes** (each calls `requireAdmin()` *before* any privileged op; 503 if service-role unconfigured):
  - `GET /api/admin/users` → mapped `AdminUserView[]` (no tokens/hashes/raw metadata).
  - `POST /api/admin/invites` → `generateLink({type:'invite'})` + branded invite email via **Resend**; duplicate → 409; if email unconfigured, still creates and returns `inviteUrl` with `emailSent:false`.
  - `DELETE /api/admin/invites/[id]` → revokes a **pending** invite only; refuses to delete active accounts (409).
- **UI** — `/admin/users` page: TanStack-Table users list (email/role/status/created/last-sign-in), invite form, per-pending-row revoke with confirm; `AdminNav` links Books ↔ Users.

## Security review result

Verdict **yes** (ship). Confirmed: no auth bypass (all routes `requireAdmin` first), service-role key isolated from client bundles, revoke can't delete active/admin users, no info disclosure, fail-closed degradation, email header/HTML injection escaped. Low/nits accepted (rate-limiting is a noted follow-up; the two medium `user_metadata` items were fixed in this PR).

## New env var (modern Supabase secret key)

- **`SUPABASE_SECRET_KEY`** (`sb_secret_*`) — server-only, from Supabase dashboard → Project Settings → **API Keys → Secret keys**. This is the **modern** key that replaces the legacy `service_role` JWT (Supabase deprecates the JWT-based keys end-of-2026). The code falls back to the legacy `SUPABASE_SERVICE_ROLE_KEY` during transition. Decision recorded in **`docs/adr/0003-supabase-api-keys.md`** (advances #52). Reuses existing `NEXT_PUBLIC_SUPABASE_URL`, `RESEND_API_KEY`, `CONTACT_FROM_EMAIL`. Until set, admin-user features return a clean 503; the rest of the site is unaffected.

## Also in this PR (CI green)

- **Regenerated `packages/mcp-client`** from the live OpenAPI spec — the server added **Article CRUD** endpoints, so the committed client had drifted and failed the `verify-mcp-client` gate. Purely additive (also useful for the future #87/#88 articles pipeline).
- **cspell**: added `Résumé`/`Supabase`/`Resend` to the dictionary (fixes the `content-checks` job that flagged "Résumé" from the resume PR).

## Verification

- `pnpm run lint` clean · `pnpm run build` succeeds **without** the service-role key (graceful degradation) · `pnpm test` **173/173** (+37 incl. the privilege-escalation guard test).

## Follow-ups

- Live smoke test (list/invite/revoke) needs `SUPABASE_SERVICE_ROLE_KEY` set locally; an e2e spec for the invite flow can be added to the #84 suite.
- Optional: per-admin invite rate-limiting.

Closes #51.
