### PR TITLE
chore: MCP API client ADR + public contact email (#52)

### DIFF
--- a/docs/adr/0004-mcp-api-client.md
+++ b/docs/adr/0004-mcp-api-client.md
@@ -1,0 +1,76 @@
+# ADR 0004 — MCP API client (generation, auth, CI validation)
+
+Date: 2026-06-28
+
+Status: Accepted
+
+## Context
+
+The site's dynamic data (Books, Authors, Ratings, and now Articles) lives in the
+**MCP server** (`bad-mcp.onrender.com`) and its own Postgres — not in Supabase
+(which the site uses only for auth; see ADR 0003). The website must call the MCP
+server's HTTP API for both public reads and admin writes.
+
+We need decisions on three things:
+
+1. **How the client is produced** — hand-written vs. generated from the API
+   contract.
+2. **How requests authenticate** — the MCP server runs two auth layers (a
+   gateway API key, and a per-user Supabase JWT for `@Security('jwt', ['admin'])`
+   routes).
+3. **How we keep the client honest** — preventing drift between the committed
+   client and the live API contract.
+
+## Decision
+
+- **Generate the client** from the MCP server's OpenAPI/Swagger spec using
+  `swagger-typescript-api`, into the local workspace package
+  `@bryandebaun/mcp-client` (`packages/mcp-client`). Regenerate with
+  `pnpm run generate:mcp-client` (`scripts/generate-mcp-client.ts`, which fetches
+  the spec using `MCP_API_KEY`). The generated client is committed.
+- **Wrap the generated client** in `src/lib/mcp.ts` (`createApi(userToken?)`),
+  which is the single place auth headers are assembled. Two-factor scheme:
+  - **Reads / server-to-server:** `Authorization: Bearer <MCP_API_KEY>`.
+  - **Admin writes (Supabase user):** `Authorization: Bearer <Supabase JWT>`
+    (satisfies the server's `jwtMiddleware` + `@Security('jwt',['admin'])`) **and**
+    `X-MCP-Api-Key: <MCP_API_KEY>` (satisfies the gateway `mcpAuthMiddleware`).
+    The gateway key moves to the `X-MCP-Api-Key` header precisely so it doesn't
+    contend with the JWT for the `Authorization` slot. This matches the server's
+    `src/http/middleware/mcp-auth.ts`.
+  - Admin role itself is `app_metadata.role` (see ADR 0003), enforced by
+    `requireAdmin()` before any privileged MCP call.
+- **Validate in CI**: the `verify-mcp-client` workflow regenerates the client
+  from the live spec and fails on any diff in `packages/mcp-client/src`, so the
+  committed client can never silently drift from the contract. When the server
+  adds endpoints (e.g. the Article CRUD endpoints added in 2026-06), the gate
+  fails until the client is regenerated and committed.
+
+## Consequences
+
+- Pros:
+  - The client always reflects the real API contract; types are free and accurate.
+  - One audited choke point (`src/lib/mcp.ts`) for auth header assembly — no
+    ad-hoc credential handling scattered across call sites.
+  - CI catches contract drift automatically (issues #53/#54).
+- Cons:
+  - Regeneration depends on reaching the live spec with `MCP_API_KEY`; the CI job
+    can fail environmentally if the spec endpoint/secret is unavailable (it is a
+    non-required check for this reason — only `build` blocks merges).
+  - A generated client occasionally needs a manual regen + commit when the server
+    evolves (a deliberate, reviewable step rather than silent updates).
+
+## Rollout / Rollback
+
+- Regenerate after any MCP server API change: `pnpm run generate:mcp-client`
+  (needs `MCP_API_KEY` in `.env.local`), then `pnpm run build:packages`, commit.
+- Rollback is a `git revert` of the regenerated client; the wrapper in
+  `src/lib/mcp.ts` is stable across regenerations.
+
+## Related
+
+- ADR 0003 (Supabase API keys & admin auth model) — together these two ADRs
+  satisfy issue **#52** ("ADR: Auth & API Client decisions"): 0003 is the auth
+  half, 0004 is the API-client half.
+- Issues #53/#54 — MCP client generation + CI validation (already shipped).
+
+Author: Bryan DeBaun

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -7,11 +7,13 @@
 /**
  * Public-facing contact email used for the `mailto:` fallback link on the
  * contact page. This is intentionally a public address (NOT the server-only
- * `CONTACT_TO_EMAIL`), so it is safe to ship to the client.
+ * `CONTACT_TO_EMAIL`), so it is safe to ship to the client. The working contact
+ * form is the primary path; this is only the no-JS / send-down fallback.
  *
- * TODO(bryan): replace this placeholder with the real public contact address.
+ * Swap to an `@bryandebaun.dev` alias if you prefer a domain address over the
+ * personal inbox here.
  */
-export const CONTACT_EMAIL = 'hello@bryandebaun.dev';
+export const CONTACT_EMAIL = 'brn.dbn@gmail.com';
 
 /** Field length bounds, shared so client + server validation stay in sync. */
 export const NAME_MIN = 1;


### PR DESCRIPTION
﻿## Summary

Tooling/cleanup sweep — completes the #52 ADR pair and sets the public contact email.

- **`docs/adr/0004-mcp-api-client.md`** — codifies the MCP API client decisions: generated client (`swagger-typescript-api` → `@bryandebaun/mcp-client`), the two-factor auth scheme in `src/lib/mcp.ts` (Supabase JWT in `Authorization` + gateway key in `X-MCP-Api-Key`), and the `verify-mcp-client` CI drift gate. Together with **ADR 0003** (Supabase API keys & admin model, already merged) this satisfies **#52**.
- **`src/lib/contact.ts`** — set the public `mailto:` fallback `CONTACT_EMAIL` to `brn.dbn@gmail.com` (was a placeholder). Swappable to an `@bryandebaun.dev` alias.

## Also done in this sweep (no code)

- **Closed #20** — MDX-aware linting is in place (eslint-plugin-mdx + the remark-frontmatter v5 fix from #89; documented in #95).
- **Status-noted #69 / #68 / #8** — recorded what shipped vs. what's deferred so the board reflects reality.

## Verification

- `pnpm run lint` clean · `pnpm run lint:content` 0 errors.

Closes #52.
