### PR TITLE
feat: admin authoring UI for articles — editor + draft/publish (#88)

### DIFF
--- a/src/app/admin/articles/[slug]/edit/page.tsx
+++ b/src/app/admin/articles/[slug]/edit/page.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import AdminNav from '@/components/admin/AdminNav';
+import ArticleEditor from '@/components/admin/ArticleEditor';
+import { requireAdminPage } from '@/lib/auth-guard';
+import { getAdminArticleBySlug } from '@/lib/services/admin-articles';
+
+export const dynamic = 'force-dynamic';
+
+export default async function EditArticlePage({
+    params,
+}: {
+    params: Promise<{ slug: string }>;
+}) {
+    // SECURITY: server-side admin guard before loading the (possibly draft)
+    // article — non-admins are redirected and never see draft content.
+    await requireAdminPage();
+
+    const { slug } = await params;
+    const article = await getAdminArticleBySlug(slug);
+    if (!article) {
+        notFound();
+    }
+
+    return (
+        <main className="p-6">
+            <h1 className="text-2xl font-semibold mb-6">Admin</h1>
+            <AdminNav />
+            <section>
+                <div className="mb-4 flex items-center justify-between">
+                    <h2 className="text-xl font-semibold">Edit article</h2>
+                    <Link href="/admin/articles" className="text-sm underline">
+                        Back to articles
+                    </Link>
+                </div>
+                <ArticleEditor mode="edit" article={article} />
+            </section>
+        </main>
+    );
+}

--- a/src/app/admin/articles/new/page.tsx
+++ b/src/app/admin/articles/new/page.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import AdminNav from '@/components/admin/AdminNav';
+import ArticleEditor from '@/components/admin/ArticleEditor';
+import { requireAdminPage } from '@/lib/auth-guard';
+
+export const dynamic = 'force-dynamic';
+
+export default async function NewArticlePage() {
+    // SECURITY: server-side admin guard — non-admins are redirected before any
+    // editor UI is sent to the browser.
+    await requireAdminPage();
+
+    return (
+        <main className="p-6">
+            <h1 className="text-2xl font-semibold mb-6">Admin</h1>
+            <AdminNav />
+            <section>
+                <div className="mb-4 flex items-center justify-between">
+                    <h2 className="text-xl font-semibold">New article</h2>
+                    <Link href="/admin/articles" className="text-sm underline">
+                        Back to articles
+                    </Link>
+                </div>
+                <ArticleEditor mode="create" />
+            </section>
+        </main>
+    );
+}

--- a/src/app/admin/articles/page.tsx
+++ b/src/app/admin/articles/page.tsx
@@ -1,0 +1,22 @@
+import AdminNav from '@/components/admin/AdminNav';
+import ArticlesAdmin from '@/components/admin/ArticlesAdmin';
+import { requireAdminPage } from '@/lib/auth-guard';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AdminArticlesPage() {
+    // SECURITY: app_metadata-based guard (same secure logic as the API
+    // `requireAdmin`). Redirects unauthenticated → /login, non-admin → /.
+    await requireAdminPage();
+
+    return (
+        <main className="p-6">
+            <h1 className="text-2xl font-semibold mb-6">Admin</h1>
+            <AdminNav />
+            <section>
+                <h2 className="text-xl font-semibold mb-4">Articles</h2>
+                <ArticlesAdmin />
+            </section>
+        </main>
+    );
+}

--- a/src/app/api/admin/articles/[slug]/__tests__/route.test.ts
+++ b/src/app/api/admin/articles/[slug]/__tests__/route.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+vi.mock('@/lib/auth-guard', () => ({
+    requireAdmin: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: vi.fn().mockResolvedValue({
+        auth: {
+            getSession: vi.fn().mockResolvedValue({
+                data: { session: { access_token: 'mock-jwt-token' } },
+                error: null,
+            }),
+        },
+    }),
+}));
+
+const revalidatePath = vi.fn();
+vi.mock('next/cache', () => ({
+    revalidatePath: (path: string) => revalidatePath(path),
+}));
+
+import { requireAdmin } from '@/lib/auth-guard';
+
+const updateArticle = vi.fn();
+const deleteArticle = vi.fn();
+
+vi.mock('@bryandebaun/mcp-client', async (importOriginal) => {
+    const original = (await importOriginal()) as Record<string, unknown>;
+    return {
+        ...original,
+        Api: class {
+            setSecurityData = vi.fn();
+            api = {
+                updateArticle: (...args: unknown[]) => updateArticle(...args),
+                deleteArticle: (...args: unknown[]) => deleteArticle(...args),
+            };
+        },
+    };
+});
+
+const unauthorizedResponse = new Response(
+    JSON.stringify({ error: 'Unauthorized' }),
+    { status: 401 },
+);
+const forbiddenResponse = new Response(JSON.stringify({ error: 'Forbidden' }), {
+    status: 403,
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    (requireAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    updateArticle.mockResolvedValue({
+        data: { id: 1, slug: 'cptsd', title: 'CPTSD', status: 'published' },
+    });
+    deleteArticle.mockResolvedValue({});
+});
+
+describe('PUT /api/admin/articles/[slug]', () => {
+    it('updates (publish) and revalidates the public path', async () => {
+        const route = await import('../route');
+        const req = new Request('http://localhost/api/admin/articles/cptsd', {
+            method: 'PUT',
+            body: JSON.stringify({ status: 'published' }),
+        });
+        const res = await route.PUT(req as unknown as NextRequest, {
+            params: { slug: 'cptsd' },
+        });
+        const json = await (res as Response).json();
+        expect(json.status).toBe('published');
+        expect(updateArticle).toHaveBeenCalledWith('cptsd', {
+            status: 'published',
+        });
+        expect(revalidatePath).toHaveBeenCalledWith('/philosophy/cptsd');
+    });
+
+    it('revalidates both old and new slug on a rename', async () => {
+        const route = await import('../route');
+        const req = new Request('http://localhost/api/admin/articles/old', {
+            method: 'PUT',
+            body: JSON.stringify({ newSlug: 'new' }),
+        });
+        await route.PUT(req as unknown as NextRequest, {
+            params: { slug: 'old' },
+        });
+        expect(revalidatePath).toHaveBeenCalledWith('/philosophy/new');
+        expect(revalidatePath).toHaveBeenCalledWith('/philosophy/old');
+    });
+
+    it('surfaces a slug conflict as a 400 field error', async () => {
+        updateArticle.mockRejectedValueOnce({ response: { status: 400 } });
+        const route = await import('../route');
+        const req = new Request('http://localhost/api/admin/articles/cptsd', {
+            method: 'PUT',
+            body: JSON.stringify({ newSlug: 'taken' }),
+        });
+        const res = await route.PUT(req as unknown as NextRequest, {
+            params: { slug: 'cptsd' },
+        });
+        expect((res as Response).status).toBe(400);
+        const json = await (res as Response).json();
+        expect(json.fieldErrors.slug).toBeTruthy();
+    });
+
+    it('returns 401 when not authenticated', async () => {
+        (requireAdmin as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+            unauthorizedResponse,
+        );
+        const route = await import('../route');
+        const req = new Request('http://localhost/api/admin/articles/x', {
+            method: 'PUT',
+            body: JSON.stringify({ title: 'x' }),
+        });
+        const res = await route.PUT(req as unknown as NextRequest, {
+            params: { slug: 'x' },
+        });
+        expect((res as Response).status).toBe(401);
+    });
+
+    it('returns 403 when not admin', async () => {
+        (requireAdmin as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+            forbiddenResponse,
+        );
+        const route = await import('../route');
+        const req = new Request('http://localhost/api/admin/articles/x', {
+            method: 'PUT',
+            body: JSON.stringify({ title: 'x' }),
+        });
+        const res = await route.PUT(req as unknown as NextRequest, {
+            params: { slug: 'x' },
+        });
+        expect((res as Response).status).toBe(403);
+    });
+});
+
+describe('DELETE /api/admin/articles/[slug]', () => {
+    it('deletes and revalidates, returning 204', async () => {
+        const route = await import('../route');
+        const req = new Request('http://localhost/api/admin/articles/cptsd', {
+            method: 'DELETE',
+        });
+        const res = await route.DELETE(req as unknown as NextRequest, {
+            params: { slug: 'cptsd' },
+        });
+        expect((res as Response).status).toBe(204);
+        expect(deleteArticle).toHaveBeenCalledWith('cptsd');
+        expect(revalidatePath).toHaveBeenCalledWith('/philosophy');
+        expect(revalidatePath).toHaveBeenCalledWith('/philosophy/cptsd');
+    });
+
+    it('returns 401 when not authenticated', async () => {
+        (requireAdmin as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+            unauthorizedResponse,
+        );
+        const route = await import('../route');
+        const req = new Request('http://localhost/api/admin/articles/x', {
+            method: 'DELETE',
+        });
+        const res = await route.DELETE(req as unknown as NextRequest, {
+            params: { slug: 'x' },
+        });
+        expect((res as Response).status).toBe(401);
+    });
+
+    it('returns 403 when not admin', async () => {
+        (requireAdmin as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+            forbiddenResponse,
+        );
+        const route = await import('../route');
+        const req = new Request('http://localhost/api/admin/articles/x', {
+            method: 'DELETE',
+        });
+        const res = await route.DELETE(req as unknown as NextRequest, {
+            params: { slug: 'x' },
+        });
+        expect((res as Response).status).toBe(403);
+    });
+});

--- a/src/app/api/admin/articles/[slug]/route.ts
+++ b/src/app/api/admin/articles/[slug]/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { revalidatePath } from 'next/cache';
+import type { UpdateArticleRequest } from '@bryandebaun/mcp-client';
+import { requireAdmin } from '@/lib/auth-guard';
+import { unwrapApiResponse } from '@/lib/api-response';
+import { createClient } from '@/lib/supabase/server';
+import {
+    isSlugConflictError,
+    revalidateArticlePaths,
+} from '@/lib/admin-articles';
+
+import { createApi as _createApi } from '@/lib/mcp';
+export function createApi(token?: string) {
+    return _createApi(token);
+}
+
+type RouteContext = {
+    params: { slug: string } | Promise<{ slug: string }>;
+};
+
+/**
+ * PUT /api/admin/articles/[slug]
+ *
+ * Updates an article (title/body/summary/tags, `status` transitions such as
+ * publish/unpublish, `publishedAt`, and `newSlug` renames). On success the
+ * public philosophy paths are revalidated — both the old and the new slug when
+ * a rename occurs — so publish/unpublish is reflected immediately.
+ */
+export async function PUT(req: NextRequest, context: RouteContext) {
+    const guard = await requireAdmin();
+    if (guard) return guard;
+
+    const supabase = await createClient();
+    const {
+        data: { session },
+    } = await supabase.auth.getSession();
+    const params = await context.params;
+    const slug = params.slug;
+    const api = createApi(session?.access_token);
+
+    const payload = (await req.json()) as UpdateArticleRequest;
+
+    try {
+        const res = await api.api.updateArticle(slug, payload);
+        const updated = unwrapApiResponse(res);
+        revalidateArticlePaths(revalidatePath, payload.newSlug ?? slug, slug);
+        return NextResponse.json(updated);
+    } catch (e) {
+        if (isSlugConflictError(e)) {
+            return NextResponse.json(
+                { fieldErrors: { slug: 'That slug is already in use.' } },
+                { status: 400 },
+            );
+        }
+        console.error('Admin: failed to update article', e);
+        return NextResponse.json(
+            { error: 'Failed to update article' },
+            { status: 502 },
+        );
+    }
+}
+
+/**
+ * DELETE /api/admin/articles/[slug]
+ *
+ * Deletes an article and revalidates the public philosophy paths so the
+ * removed article disappears from the index and 404s on its slug page.
+ */
+export async function DELETE(_req: NextRequest, context: RouteContext) {
+    const guard = await requireAdmin();
+    if (guard) return guard;
+
+    const supabase = await createClient();
+    const {
+        data: { session },
+    } = await supabase.auth.getSession();
+    const params = await context.params;
+    const slug = params.slug;
+    const api = createApi(session?.access_token);
+
+    try {
+        await api.api.deleteArticle(slug);
+        revalidateArticlePaths(revalidatePath, slug);
+        return new NextResponse(null, { status: 204 });
+    } catch (e) {
+        console.error('Admin: failed to delete article', e);
+        return NextResponse.json(
+            { error: 'Failed to delete article' },
+            { status: 502 },
+        );
+    }
+}

--- a/src/app/api/admin/articles/__tests__/route.test.ts
+++ b/src/app/api/admin/articles/__tests__/route.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+// Default: admin allowed. Individual tests can override with mockResolvedValueOnce.
+vi.mock('@/lib/auth-guard', () => ({
+    requireAdmin: vi.fn().mockResolvedValue(null),
+}));
+
+// Mock Supabase server client so routes that call getSession() don't need the
+// Next.js request store (cookies) active during unit tests.
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: vi.fn().mockResolvedValue({
+        auth: {
+            getSession: vi.fn().mockResolvedValue({
+                data: { session: { access_token: 'mock-jwt-token' } },
+                error: null,
+            }),
+        },
+    }),
+}));
+
+// Capture revalidatePath calls so we can assert the public paths are busted.
+const revalidatePath = vi.fn();
+vi.mock('next/cache', () => ({
+    revalidatePath: (path: string) => revalidatePath(path),
+}));
+
+import { requireAdmin } from '@/lib/auth-guard';
+
+// Mutable handles so individual tests can change client behaviour (e.g. reject).
+const listArticles = vi.fn();
+const createArticle = vi.fn();
+
+vi.mock('@bryandebaun/mcp-client', async (importOriginal) => {
+    const original = (await importOriginal()) as Record<string, unknown>;
+    return {
+        ...original,
+        Api: class {
+            setSecurityData = vi.fn();
+            api = {
+                listArticles: (...args: unknown[]) => listArticles(...args),
+                createArticle: (...args: unknown[]) => createArticle(...args),
+            };
+        },
+    };
+});
+
+const unauthorizedResponse = new Response(
+    JSON.stringify({ error: 'Unauthorized' }),
+    { status: 401 },
+);
+const forbiddenResponse = new Response(JSON.stringify({ error: 'Forbidden' }), {
+    status: 403,
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    (requireAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    listArticles.mockResolvedValue({
+        data: {
+            articles: [
+                { slug: 'a', title: 'A', status: 'published' },
+                { slug: 'b', title: 'B', status: 'draft' },
+            ],
+            total: 2,
+        },
+    });
+    createArticle.mockResolvedValue({
+        data: { id: 9, slug: 'new-one', title: 'New', status: 'draft' },
+    });
+});
+
+describe('GET /api/admin/articles', () => {
+    it('lists all articles including drafts (status=all)', async () => {
+        const route = await import('../route');
+        const res = await route.GET();
+        const json = await (res as Response).json();
+        expect(json.articles).toHaveLength(2);
+        expect(listArticles).toHaveBeenCalledWith({ status: 'all' });
+    });
+
+    it('returns 401 when not authenticated', async () => {
+        (requireAdmin as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+            unauthorizedResponse,
+        );
+        const route = await import('../route');
+        const res = await route.GET();
+        expect((res as Response).status).toBe(401);
+    });
+
+    it('returns 403 when not admin', async () => {
+        (requireAdmin as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+            forbiddenResponse,
+        );
+        const route = await import('../route');
+        const res = await route.GET();
+        expect((res as Response).status).toBe(403);
+    });
+});
+
+describe('POST /api/admin/articles', () => {
+    it('creates an article, returns 201, and revalidates public paths', async () => {
+        const route = await import('../route');
+        const req = new Request('http://localhost/api/admin/articles', {
+            method: 'POST',
+            body: JSON.stringify({
+                slug: 'new-one',
+                title: 'New',
+                body: 'Hi',
+            }),
+        });
+        const res = await route.POST(req as unknown as NextRequest);
+        expect((res as Response).status).toBe(201);
+        const json = await (res as Response).json();
+        expect(json.slug).toBe('new-one');
+        expect(revalidatePath).toHaveBeenCalledWith('/philosophy');
+        expect(revalidatePath).toHaveBeenCalledWith('/philosophy/new-one');
+    });
+
+    it('surfaces a slug conflict as a 400 field error', async () => {
+        createArticle.mockRejectedValueOnce({ response: { status: 400 } });
+        const route = await import('../route');
+        const req = new Request('http://localhost/api/admin/articles', {
+            method: 'POST',
+            body: JSON.stringify({
+                slug: 'taken',
+                title: 'Dup',
+                body: 'x',
+            }),
+        });
+        const res = await route.POST(req as unknown as NextRequest);
+        expect((res as Response).status).toBe(400);
+        const json = await (res as Response).json();
+        expect(json.fieldErrors.slug).toBeTruthy();
+        // No public revalidation when the create failed.
+        expect(revalidatePath).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when not authenticated', async () => {
+        (requireAdmin as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+            unauthorizedResponse,
+        );
+        const route = await import('../route');
+        const req = new Request('http://localhost/api/admin/articles', {
+            method: 'POST',
+            body: JSON.stringify({ slug: 's', title: 't', body: 'b' }),
+        });
+        const res = await route.POST(req as unknown as NextRequest);
+        expect((res as Response).status).toBe(401);
+    });
+
+    it('returns 403 when not admin', async () => {
+        (requireAdmin as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+            forbiddenResponse,
+        );
+        const route = await import('../route');
+        const req = new Request('http://localhost/api/admin/articles', {
+            method: 'POST',
+            body: JSON.stringify({ slug: 's', title: 't', body: 'b' }),
+        });
+        const res = await route.POST(req as unknown as NextRequest);
+        expect((res as Response).status).toBe(403);
+    });
+});

--- a/src/app/api/admin/articles/route.ts
+++ b/src/app/api/admin/articles/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { revalidatePath } from 'next/cache';
+import type {
+    CreateArticleRequest,
+    ListArticlesResponse,
+} from '@bryandebaun/mcp-client';
+import { ArticleReadStatus } from '@bryandebaun/mcp-client';
+import { requireAdmin } from '@/lib/auth-guard';
+import { unwrapApiResponse } from '@/lib/api-response';
+import { createClient } from '@/lib/supabase/server';
+import {
+    isSlugConflictError,
+    revalidateArticlePaths,
+} from '@/lib/admin-articles';
+
+import { createApi as _createApi } from '@/lib/mcp';
+export function createApi(token?: string) {
+    return _createApi(token);
+}
+
+/**
+ * GET /api/admin/articles
+ *
+ * Lists ALL articles including drafts (`status=all`). Admin-only — the draft
+ * visibility comes from sending the caller's Supabase JWT to the MCP server,
+ * which is what authorizes returning unpublished content.
+ */
+export async function GET() {
+    const guard = await requireAdmin();
+    if (guard) return guard;
+
+    const supabase = await createClient();
+    const {
+        data: { session },
+    } = await supabase.auth.getSession();
+    const api = createApi(session?.access_token);
+
+    try {
+        const res = await api.api.listArticles({
+            status: ArticleReadStatus.All,
+        });
+        const payload = unwrapApiResponse<ListArticlesResponse>(res);
+        return NextResponse.json({ articles: payload?.articles ?? [] });
+    } catch (e) {
+        console.error('Admin: failed to list articles', e);
+        return NextResponse.json(
+            { error: 'Failed to list articles' },
+            { status: 502 },
+        );
+    }
+}
+
+/**
+ * POST /api/admin/articles
+ *
+ * Creates a new article. A duplicate slug is surfaced as a clean 400 field
+ * error so the editor can show it inline. On success we revalidate the public
+ * philosophy paths so a freshly-published article appears without waiting out
+ * the ISR window.
+ */
+export async function POST(req: NextRequest) {
+    const guard = await requireAdmin();
+    if (guard) return guard;
+
+    const supabase = await createClient();
+    const {
+        data: { session },
+    } = await supabase.auth.getSession();
+    const api = createApi(session?.access_token);
+
+    const payload = (await req.json()) as CreateArticleRequest;
+
+    try {
+        const res = await api.api.createArticle(payload);
+        const created = unwrapApiResponse(res);
+        revalidateArticlePaths(revalidatePath, payload.slug);
+        return NextResponse.json(created, { status: 201 });
+    } catch (e) {
+        if (isSlugConflictError(e)) {
+            return NextResponse.json(
+                { fieldErrors: { slug: 'That slug is already in use.' } },
+                { status: 400 },
+            );
+        }
+        console.error('Admin: failed to create article', e);
+        return NextResponse.json(
+            { error: 'Failed to create article' },
+            { status: 502 },
+        );
+    }
+}

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -16,6 +16,11 @@ export default function AdminNav() {
                     </Link>
                 </li>
                 <li>
+                    <Link href="/admin/articles" className={linkClass}>
+                        Articles
+                    </Link>
+                </li>
+                <li>
                     <Link href="/admin/users" className={linkClass}>
                         Users
                     </Link>

--- a/src/components/admin/ArticleEditor.tsx
+++ b/src/components/admin/ArticleEditor.tsx
@@ -1,0 +1,379 @@
+'use client';
+
+import React, { useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import type { Article } from '@bryandebaun/mcp-client';
+import { ArticleStatus } from '@bryandebaun/mcp-client';
+import ArticleBody from '@/components/ArticleBody';
+import { useAdminArticles } from '@/lib/hooks/useAdminArticles';
+import { ArticleFieldError } from '@/lib/repositories/articlesRepository';
+import { slugify } from '@/lib/slug';
+import {
+    emptyArticleForm,
+    formFromArticle,
+    toCreateRequest,
+    toUpdateRequest,
+    validateArticleForm,
+    type ArticleFormValues,
+} from '@/lib/article-editor';
+
+type Props = {
+    mode: 'create' | 'edit';
+    /** The existing article when editing. Undefined for the create flow. */
+    article?: Article;
+};
+
+type FieldErrors = Partial<Record<'title' | 'slug' | 'body', string>>;
+
+function normalise(s: string) {
+    return s.trim().toLowerCase();
+}
+
+/**
+ * Shared admin article editor: form fields + a Markdown body editor with a live
+ * preview rendered via the SAME {@link ArticleBody} component the public page
+ * uses, guaranteeing the preview matches the published render exactly.
+ */
+export default function ArticleEditor({ mode, article }: Props) {
+    const router = useRouter();
+    const { createMutation, updateMutation } = useAdminArticles();
+
+    const [values, setValues] = useState<ArticleFormValues>(() =>
+        article ? formFromArticle(article) : emptyArticleForm(),
+    );
+    // For create: keep the slug synced to the title until the user edits it.
+    const [slugDirty, setSlugDirty] = useState(mode === 'edit');
+    const [tagInput, setTagInput] = useState('');
+    const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+    const [formError, setFormError] = useState<string | null>(null);
+    const tagInputRef = useRef<HTMLInputElement>(null);
+
+    const isSaving = createMutation.isPending || updateMutation.isPending;
+    const currentStatus = article?.status ?? ArticleStatus.Draft;
+    const isPublished = currentStatus === ArticleStatus.Published;
+
+    const setField = <K extends keyof ArticleFormValues>(
+        key: K,
+        value: ArticleFormValues[K],
+    ) => {
+        setValues((prev) => ({ ...prev, [key]: value }));
+    };
+
+    const handleTitleChange = (title: string) => {
+        setValues((prev) => ({
+            ...prev,
+            title,
+            slug: slugDirty ? prev.slug : slugify(title),
+        }));
+    };
+
+    const handleSlugChange = (slug: string) => {
+        setSlugDirty(true);
+        setField('slug', slug);
+    };
+
+    function commitTag(raw: string) {
+        const tag = raw.trim();
+        if (!tag) return;
+        if (values.tags.some((t) => normalise(t) === normalise(tag))) {
+            setTagInput('');
+            return;
+        }
+        setValues((prev) => ({ ...prev, tags: [...prev.tags, tag] }));
+        setTagInput('');
+        tagInputRef.current?.focus();
+    }
+
+    function removeTag(index: number) {
+        setValues((prev) => ({
+            ...prev,
+            tags: prev.tags.filter((_, i) => i !== index),
+        }));
+    }
+
+    function handleTagKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+        if (e.key === 'Enter' || e.key === ',') {
+            e.preventDefault();
+            commitTag(tagInput);
+        }
+        if (e.key === 'Backspace' && tagInput === '' && values.tags.length > 0) {
+            removeTag(values.tags.length - 1);
+        }
+    }
+
+    async function save(targetStatus: ArticleStatus) {
+        setFormError(null);
+        setFieldErrors({});
+
+        // Commit any in-progress tag input before validating/submitting.
+        const pendingTag = tagInput.trim();
+        const submitValues: ArticleFormValues = pendingTag
+            ? {
+                  ...values,
+                  tags: values.tags.some(
+                      (t) => normalise(t) === normalise(pendingTag),
+                  )
+                      ? values.tags
+                      : [...values.tags, pendingTag],
+              }
+            : values;
+
+        const validation = validateArticleForm(submitValues);
+        if (!validation.ok) {
+            setFieldErrors(validation.errors);
+            return;
+        }
+
+        try {
+            if (mode === 'create') {
+                await createMutation.mutateAsync(
+                    toCreateRequest(submitValues, targetStatus),
+                );
+            } else if (article) {
+                await updateMutation.mutateAsync({
+                    slug: article.slug,
+                    data: toUpdateRequest(
+                        submitValues,
+                        article,
+                        targetStatus,
+                    ),
+                });
+            }
+            router.push('/admin/articles');
+            router.refresh();
+        } catch (err) {
+            if (err instanceof ArticleFieldError) {
+                setFieldErrors(err.fieldErrors as FieldErrors);
+                return;
+            }
+            setFormError(
+                (err as Error).message ?? 'Failed to save the article.',
+            );
+        }
+    }
+
+    const previewBody = useMemo(() => values.body, [values.body]);
+
+    return (
+        <div className="space-y-6">
+            <form
+                onSubmit={(e) => e.preventDefault()}
+                className="grid grid-cols-1 gap-6 lg:grid-cols-2"
+                aria-label={mode === 'create' ? 'New article' : 'Edit article'}
+            >
+                {/* Left column: form fields + Markdown body */}
+                <div className="space-y-4">
+                    <div>
+                        <label
+                            htmlFor="article-title"
+                            className="block text-sm font-medium"
+                        >
+                            Title{' '}
+                            <span className="text-red-500" aria-hidden="true">
+                                *
+                            </span>
+                        </label>
+                        <input
+                            id="article-title"
+                            type="text"
+                            className="mt-1 w-full form-input"
+                            value={values.title}
+                            onChange={(e) => handleTitleChange(e.target.value)}
+                            aria-invalid={Boolean(fieldErrors.title)}
+                        />
+                        {fieldErrors.title ? (
+                            <p className="mt-1 text-xs text-red-600" role="alert">
+                                {fieldErrors.title}
+                            </p>
+                        ) : null}
+                    </div>
+
+                    <div>
+                        <label
+                            htmlFor="article-slug"
+                            className="block text-sm font-medium"
+                        >
+                            Slug{' '}
+                            <span className="text-red-500" aria-hidden="true">
+                                *
+                            </span>
+                        </label>
+                        <input
+                            id="article-slug"
+                            type="text"
+                            className="mt-1 w-full form-input"
+                            value={values.slug}
+                            onChange={(e) => handleSlugChange(e.target.value)}
+                            aria-invalid={Boolean(fieldErrors.slug)}
+                            autoComplete="off"
+                        />
+                        <p className="mt-1 text-xs text-[var(--color-norwegian-500)] dark:text-[var(--color-norwegian-400)]">
+                            Lives at <code>/philosophy/{values.slug || '…'}</code>
+                        </p>
+                        {fieldErrors.slug ? (
+                            <p className="mt-1 text-xs text-red-600" role="alert">
+                                {fieldErrors.slug}
+                            </p>
+                        ) : null}
+                    </div>
+
+                    <div>
+                        <label
+                            htmlFor="article-summary"
+                            className="block text-sm font-medium"
+                        >
+                            Summary
+                        </label>
+                        <textarea
+                            id="article-summary"
+                            className="mt-1 w-full form-input"
+                            rows={2}
+                            value={values.summary}
+                            onChange={(e) => setField('summary', e.target.value)}
+                        />
+                    </div>
+
+                    <div>
+                        <label
+                            htmlFor="article-tag-input"
+                            className="block text-sm font-medium mb-1"
+                        >
+                            Tags
+                        </label>
+                        {values.tags.length > 0 ? (
+                            <div className="flex flex-wrap gap-1 mb-2">
+                                {values.tags.map((tag, i) => (
+                                    <span
+                                        key={`${tag}-${i}`}
+                                        className="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium bg-[var(--btn-accent)]/15 text-[var(--color-norwegian-700)] dark:text-[var(--tw-prose-invert-body)] border border-[var(--btn-accent)]/30"
+                                    >
+                                        {tag}
+                                        <button
+                                            type="button"
+                                            aria-label={`Remove ${tag}`}
+                                            className="leading-none hover:text-red-500 cursor-pointer"
+                                            onClick={() => removeTag(i)}
+                                        >
+                                            &times;
+                                        </button>
+                                    </span>
+                                ))}
+                            </div>
+                        ) : null}
+                        <input
+                            id="article-tag-input"
+                            ref={tagInputRef}
+                            type="text"
+                            className="w-full form-input"
+                            placeholder="Type a tag and press Enter or comma"
+                            value={tagInput}
+                            autoComplete="off"
+                            onChange={(e) => setTagInput(e.target.value)}
+                            onBlur={() => commitTag(tagInput)}
+                            onKeyDown={handleTagKeyDown}
+                        />
+                    </div>
+
+                    <div>
+                        <label
+                            htmlFor="article-body"
+                            className="block text-sm font-medium"
+                        >
+                            Body (Markdown){' '}
+                            <span className="text-red-500" aria-hidden="true">
+                                *
+                            </span>
+                        </label>
+                        <textarea
+                            id="article-body"
+                            className="mt-1 w-full form-input font-mono text-sm"
+                            rows={20}
+                            value={values.body}
+                            onChange={(e) => setField('body', e.target.value)}
+                            aria-invalid={Boolean(fieldErrors.body)}
+                            spellCheck
+                        />
+                        {fieldErrors.body ? (
+                            <p className="mt-1 text-xs text-red-600" role="alert">
+                                {fieldErrors.body}
+                            </p>
+                        ) : null}
+                    </div>
+                </div>
+
+                {/* Right column: live preview via the public ArticleBody */}
+                <div>
+                    <p className="block text-sm font-medium mb-1">Preview</p>
+                    <div className="rounded-lg border border-[var(--tw-prose-td-borders)] dark:border-[var(--tw-prose-invert-td-borders)] bg-[var(--background)] p-4 max-h-[40rem] overflow-y-auto">
+                        {values.title ? (
+                            <h1 className="text-center text-2xl font-semibold mb-4">
+                                {values.title}
+                            </h1>
+                        ) : null}
+                        <ArticleBody body={previewBody} />
+                    </div>
+                    <p className="mt-1 text-xs text-[var(--color-norwegian-500)] dark:text-[var(--color-norwegian-400)]">
+                        Rendered with the same component as the public article
+                        page.
+                    </p>
+                </div>
+            </form>
+
+            {formError ? (
+                <p role="alert" className="text-sm text-red-600">
+                    {formError}
+                </p>
+            ) : null}
+
+            <div className="flex flex-wrap items-center gap-3 border-t border-[var(--tw-prose-td-borders)] pt-4">
+                <button
+                    type="button"
+                    className="btn btn--primary"
+                    disabled={isSaving}
+                    onClick={() => save(ArticleStatus.Draft)}
+                >
+                    {isSaving ? 'Saving…' : 'Save as draft'}
+                </button>
+
+                {isPublished ? (
+                    <>
+                        <button
+                            type="button"
+                            className="btn btn--primary"
+                            disabled={isSaving}
+                            onClick={() => save(ArticleStatus.Published)}
+                        >
+                            Save (published)
+                        </button>
+                        <button
+                            type="button"
+                            className="btn"
+                            disabled={isSaving}
+                            onClick={() => save(ArticleStatus.Draft)}
+                        >
+                            Unpublish
+                        </button>
+                    </>
+                ) : (
+                    <button
+                        type="button"
+                        className="btn btn--primary"
+                        disabled={isSaving}
+                        onClick={() => save(ArticleStatus.Published)}
+                    >
+                        Publish
+                    </button>
+                )}
+
+                <button
+                    type="button"
+                    className="btn"
+                    disabled={isSaving}
+                    onClick={() => router.push('/admin/articles')}
+                >
+                    Cancel
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/admin/ArticlesAdmin.tsx
+++ b/src/components/admin/ArticlesAdmin.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useMemo } from 'react';
+import Link from 'next/link';
+import type { CellContext, ColumnDef } from '@tanstack/react-table';
+import type { Article } from '@bryandebaun/mcp-client';
+import { ArticleStatus } from '@bryandebaun/mcp-client';
+import Table from '@/components/Table';
+import { useAdminArticles } from '@/lib/hooks/useAdminArticles';
+import { toUpdateRequest } from '@/lib/article-editor';
+import { formatDate } from '@/lib/dates';
+
+function StatusPill({ status }: { status: ArticleStatus }) {
+    const classes =
+        status === ArticleStatus.Published
+            ? 'bg-gradient-to-b from-[var(--color-norwegian-500)] to-[var(--color-norwegian-400)] text-[var(--color-white)] border border-[rgba(0,0,0,0.06)] shadow-sm'
+            : 'bg-[var(--color-norwegian-50)] text-[var(--color-norwegian-700)] dark:bg-[var(--color-norwegian-100-dark)] dark:text-[var(--color-norwegian-300-dark)]';
+    return (
+        <span
+            className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${classes}`}
+        >
+            {status}
+        </span>
+    );
+}
+
+export default function ArticlesAdmin() {
+    const { articles, isError, error, updateMutation, deleteMutation } =
+        useAdminArticles();
+
+    const handleTogglePublish = (article: Article) => {
+        const target =
+            article.status === ArticleStatus.Published
+                ? ArticleStatus.Draft
+                : ArticleStatus.Published;
+        updateMutation.mutate({
+            slug: article.slug,
+            data: toUpdateRequest(
+                {
+                    title: article.title,
+                    slug: article.slug,
+                    summary: article.summary ?? '',
+                    tags: article.tags ?? [],
+                    body: article.body,
+                },
+                article,
+                target,
+            ),
+        });
+    };
+
+    const handleDelete = (article: Article) => {
+        if (
+            !window.confirm(
+                `Delete the article “${article.title}”? This cannot be undone.`,
+            )
+        ) {
+            return;
+        }
+        deleteMutation.mutate(article.slug);
+    };
+
+    const columns = useMemo<ColumnDef<Article, unknown>[]>(
+        () => [
+            {
+                id: 'title',
+                header: 'Title',
+                meta: {
+                    headerClassName: 'text-left',
+                    cellClassName: 'text-left',
+                },
+                cell: (info: CellContext<Article, unknown>) => (
+                    <Link
+                        href={`/admin/articles/${encodeURIComponent(
+                            info.row.original.slug,
+                        )}/edit`}
+                        className="font-medium underline"
+                    >
+                        {info.row.original.title}
+                    </Link>
+                ),
+            },
+            {
+                id: 'slug',
+                header: 'Slug',
+                meta: {
+                    headerClassName: 'text-left',
+                    cellClassName: 'text-left',
+                },
+                cell: (info: CellContext<Article, unknown>) => (
+                    <code className="text-xs">{info.row.original.slug}</code>
+                ),
+            },
+            {
+                id: 'status',
+                header: 'Status',
+                cell: (info: CellContext<Article, unknown>) => (
+                    <StatusPill status={info.row.original.status} />
+                ),
+            },
+            {
+                id: 'publishedAt',
+                header: 'Published',
+                cell: (info: CellContext<Article, unknown>) =>
+                    formatDate(info.row.original.publishedAt),
+            },
+            {
+                id: 'updatedAt',
+                header: 'Updated',
+                cell: (info: CellContext<Article, unknown>) =>
+                    formatDate(info.row.original.updatedAt),
+            },
+            {
+                id: 'actions',
+                header: 'Actions',
+                meta: {
+                    headerClassName: 'text-right',
+                    cellClassName: 'text-right',
+                },
+                cell: (info: CellContext<Article, unknown>) => {
+                    const article = info.row.original;
+                    const isPublished =
+                        article.status === ArticleStatus.Published;
+                    return (
+                        <div className="flex items-center justify-end gap-2">
+                            <button
+                                type="button"
+                                className="inline-flex items-center justify-center rounded-md px-2 py-1 text-xs cursor-pointer bg-[var(--color-norwegian-100)] dark:bg-white/10 hover:bg-[var(--color-norwegian-200)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-fjord-600)]"
+                                onClick={() => handleTogglePublish(article)}
+                                disabled={updateMutation.isPending}
+                            >
+                                {isPublished ? 'Unpublish' : 'Publish'}
+                            </button>
+                            <button
+                                type="button"
+                                className="inline-flex items-center justify-center rounded-md px-2 py-1 text-xs text-[var(--color-white)] cursor-pointer bg-gradient-to-b from-red-600 to-red-500 hover:from-red-500 hover:to-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-fjord-600)]"
+                                onClick={() => handleDelete(article)}
+                                disabled={deleteMutation.isPending}
+                            >
+                                Delete
+                            </button>
+                        </div>
+                    );
+                },
+            },
+        ],
+        // Mutation pending flags drive disabled state; handlers are stable enough.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [updateMutation.isPending, deleteMutation.isPending],
+    );
+
+    return (
+        <div>
+            <div className="mb-6 flex items-center justify-between">
+                <Link href="/admin/articles/new" className="btn btn--primary">
+                    New article
+                </Link>
+            </div>
+
+            {isError ? (
+                <p role="alert" className="mb-4 text-sm text-red-600">
+                    {error?.message ?? 'Failed to load articles.'}
+                </p>
+            ) : null}
+
+            <Table
+                data={articles}
+                columns={columns}
+                className="overflow-x-auto rounded-lg border border-[var(--tw-prose-td-borders)] dark:border-[var(--tw-prose-invert-td-borders)] bg-[var(--background)] shadow-sm ring-1 ring-[var(--tw-prose-td-borders)]"
+                caption="Admin articles list"
+            />
+        </div>
+    );
+}

--- a/src/lib/__tests__/admin-articles.test.ts
+++ b/src/lib/__tests__/admin-articles.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+    isSlugConflictError,
+    revalidateArticlePaths,
+} from '@/lib/admin-articles';
+
+describe('isSlugConflictError', () => {
+    it('detects an Axios 400 response', () => {
+        expect(isSlugConflictError({ response: { status: 400 } })).toBe(true);
+    });
+
+    it('ignores other statuses and shapes', () => {
+        expect(isSlugConflictError({ response: { status: 500 } })).toBe(false);
+        expect(isSlugConflictError(new Error('boom'))).toBe(false);
+        expect(isSlugConflictError(undefined)).toBe(false);
+    });
+});
+
+describe('revalidateArticlePaths', () => {
+    it('revalidates the index and the slug page', () => {
+        const spy = vi.fn();
+        revalidateArticlePaths(spy, 'cptsd');
+        expect(spy).toHaveBeenCalledWith('/philosophy');
+        expect(spy).toHaveBeenCalledWith('/philosophy/cptsd');
+        expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('also revalidates the previous slug on a rename', () => {
+        const spy = vi.fn();
+        revalidateArticlePaths(spy, 'new', 'old');
+        expect(spy).toHaveBeenCalledWith('/philosophy/new');
+        expect(spy).toHaveBeenCalledWith('/philosophy/old');
+    });
+
+    it('does not double-revalidate when the slug is unchanged', () => {
+        const spy = vi.fn();
+        revalidateArticlePaths(spy, 'same', 'same');
+        expect(spy).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/lib/__tests__/article-editor.test.ts
+++ b/src/lib/__tests__/article-editor.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Article } from '@bryandebaun/mcp-client';
+import { ArticleStatus } from '@bryandebaun/mcp-client';
+import {
+    emptyArticleForm,
+    formFromArticle,
+    toCreateRequest,
+    toUpdateRequest,
+    validateArticleForm,
+    type ArticleFormValues,
+} from '@/lib/article-editor';
+import { slugify } from '@/lib/slug';
+
+const baseArticle: Article = {
+    id: 1,
+    slug: 'cptsd',
+    title: 'CPTSD',
+    summary: 'A note',
+    body: '# Body',
+    status: ArticleStatus.Draft,
+    tags: ['mental-health'],
+    publishedAt: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+function validForm(overrides: Partial<ArticleFormValues> = {}): ArticleFormValues {
+    return {
+        title: 'My Title',
+        slug: 'my-title',
+        summary: 'Sum',
+        tags: ['a'],
+        body: 'Hello',
+        ...overrides,
+    };
+}
+
+describe('slugify', () => {
+    it('lowercases, strips punctuation, and collapses spaces to hyphens', () => {
+        expect(slugify('Hello, World!')).toBe('hello-world');
+        expect(slugify('  Trim   Me  ')).toBe('trim-me');
+        expect(slugify('Café Déjà')).toBe('cafe-deja');
+    });
+});
+
+describe('validateArticleForm', () => {
+    it('passes a complete form', () => {
+        expect(validateArticleForm(validForm()).ok).toBe(true);
+    });
+
+    it('flags missing required fields', () => {
+        const res = validateArticleForm(
+            validForm({ title: '  ', slug: '', body: '' }),
+        );
+        expect(res.ok).toBe(false);
+        expect(res.errors.title).toBeTruthy();
+        expect(res.errors.slug).toBeTruthy();
+        expect(res.errors.body).toBeTruthy();
+    });
+});
+
+describe('form helpers', () => {
+    it('emptyArticleForm is blank', () => {
+        expect(emptyArticleForm()).toEqual({
+            title: '',
+            slug: '',
+            summary: '',
+            tags: [],
+            body: '',
+        });
+    });
+
+    it('formFromArticle maps an article including null summary', () => {
+        const form = formFromArticle({ ...baseArticle, summary: null });
+        expect(form.summary).toBe('');
+        expect(form.tags).toEqual(['mental-health']);
+        expect(form.slug).toBe('cptsd');
+    });
+});
+
+describe('toCreateRequest', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-28T12:00:00.000Z'));
+    });
+    afterEach(() => vi.useRealTimers());
+
+    it('omits publishedAt for a draft', () => {
+        const req = toCreateRequest(validForm(), ArticleStatus.Draft);
+        expect(req.status).toBe(ArticleStatus.Draft);
+        expect(req.publishedAt).toBeUndefined();
+    });
+
+    it('stamps publishedAt when publishing', () => {
+        const req = toCreateRequest(validForm(), ArticleStatus.Published);
+        expect(req.status).toBe(ArticleStatus.Published);
+        expect(req.publishedAt).toBe('2026-06-28T12:00:00.000Z');
+    });
+
+    it('drops an empty summary', () => {
+        const req = toCreateRequest(
+            validForm({ summary: '   ' }),
+            ArticleStatus.Draft,
+        );
+        expect(req.summary).toBeUndefined();
+    });
+});
+
+describe('toUpdateRequest', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-28T12:00:00.000Z'));
+    });
+    afterEach(() => vi.useRealTimers());
+
+    it('sends newSlug only when the slug changed', () => {
+        const same = toUpdateRequest(
+            validForm({ slug: 'cptsd' }),
+            baseArticle,
+            ArticleStatus.Draft,
+        );
+        expect(same.newSlug).toBeUndefined();
+
+        const renamed = toUpdateRequest(
+            validForm({ slug: 'new-slug' }),
+            baseArticle,
+            ArticleStatus.Draft,
+        );
+        expect(renamed.newSlug).toBe('new-slug');
+    });
+
+    it('stamps publishedAt when publishing a never-published article', () => {
+        const req = toUpdateRequest(
+            validForm(),
+            { ...baseArticle, publishedAt: null },
+            ArticleStatus.Published,
+        );
+        expect(req.publishedAt).toBe('2026-06-28T12:00:00.000Z');
+    });
+
+    it('preserves the original publishedAt when re-publishing', () => {
+        const req = toUpdateRequest(
+            validForm(),
+            { ...baseArticle, publishedAt: '2025-01-01T00:00:00.000Z' },
+            ArticleStatus.Published,
+        );
+        expect(req.publishedAt).toBeUndefined();
+    });
+
+    it('flips status to draft when unpublishing without touching publishedAt', () => {
+        const req = toUpdateRequest(
+            validForm(),
+            {
+                ...baseArticle,
+                status: ArticleStatus.Published,
+                publishedAt: '2025-01-01T00:00:00.000Z',
+            },
+            ArticleStatus.Draft,
+        );
+        expect(req.status).toBe(ArticleStatus.Draft);
+        expect(req.publishedAt).toBeUndefined();
+    });
+});

--- a/src/lib/admin-articles.ts
+++ b/src/lib/admin-articles.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared helpers for the admin Articles API routes.
+ *
+ * Kept separate from the route handlers so they can be unit-tested without the
+ * Next.js request store and reused across the create/update paths.
+ */
+
+/**
+ * Detect the MCP server's "slug already exists" response. The generated Axios
+ * client throws an error whose `response.status` is 400 on a duplicate slug.
+ * We treat any 400 from create/update as a slug conflict because slug
+ * uniqueness is the only client-correctable validation the API enforces on
+ * these payloads (required fields are validated in the UI before submit).
+ */
+export function isSlugConflictError(e: unknown): boolean {
+    const status = (e as { response?: { status?: unknown } })?.response?.status;
+    return status === 400;
+}
+
+/**
+ * Revalidate the public philosophy paths affected by an article mutation.
+ *
+ * Takes `revalidatePath` as a parameter so this stays free of the
+ * `next/cache` import (which can only run inside the server runtime), making it
+ * trivially unit-testable. Always revalidates the index plus the article's
+ * slug page(s); when a slug changes on update, both the old and new slugs are
+ * revalidated.
+ */
+export function revalidateArticlePaths(
+    revalidatePath: (path: string) => void,
+    slug: string,
+    previousSlug?: string,
+): void {
+    revalidatePath('/philosophy');
+    revalidatePath(`/philosophy/${slug}`);
+    if (previousSlug && previousSlug !== slug) {
+        revalidatePath(`/philosophy/${previousSlug}`);
+    }
+}

--- a/src/lib/article-editor.ts
+++ b/src/lib/article-editor.ts
@@ -1,0 +1,106 @@
+import type {
+    Article,
+    CreateArticleRequest,
+    UpdateArticleRequest,
+} from '@bryandebaun/mcp-client';
+import { ArticleStatus } from '@bryandebaun/mcp-client';
+
+/** Editable form fields for an article. */
+export interface ArticleFormValues {
+    title: string;
+    slug: string;
+    summary: string;
+    tags: string[];
+    body: string;
+}
+
+/** A blank form for the "new article" flow. */
+export function emptyArticleForm(): ArticleFormValues {
+    return { title: '', slug: '', summary: '', tags: [], body: '' };
+}
+
+/** Populate the form from an existing article (for editing). */
+export function formFromArticle(article: Article): ArticleFormValues {
+    return {
+        title: article.title,
+        slug: article.slug,
+        summary: article.summary ?? '',
+        tags: article.tags ?? [],
+        body: article.body,
+    };
+}
+
+export interface FormValidationResult {
+    ok: boolean;
+    errors: Partial<Record<'title' | 'slug' | 'body', string>>;
+}
+
+/** Required-field validation surfaced inline in the editor before submit. */
+export function validateArticleForm(
+    values: ArticleFormValues,
+): FormValidationResult {
+    const errors: FormValidationResult['errors'] = {};
+    if (!values.title.trim()) errors.title = 'Title is required.';
+    if (!values.slug.trim()) errors.slug = 'Slug is required.';
+    if (!values.body.trim()) errors.body = 'Body is required.';
+    return { ok: Object.keys(errors).length === 0, errors };
+}
+
+/** Build the create payload for a new article at the given target status. */
+export function toCreateRequest(
+    values: ArticleFormValues,
+    status: ArticleStatus,
+): CreateArticleRequest {
+    const summary = values.summary.trim();
+    return {
+        slug: values.slug.trim(),
+        title: values.title.trim(),
+        body: values.body,
+        ...(summary ? { summary } : {}),
+        status,
+        tags: values.tags,
+        ...(status === ArticleStatus.Published
+            ? { publishedAt: new Date().toISOString() }
+            : {}),
+    };
+}
+
+/**
+ * Build the update payload for an existing article.
+ *
+ * `targetStatus` drives the draft/publish transition:
+ *  - publishing a previously-unpublished article stamps `publishedAt` only when
+ *    it was not already set (so re-publishing preserves the original date);
+ *  - unpublishing flips `status` back to draft and leaves `publishedAt` intact.
+ *
+ * A slug rename is sent via `newSlug`.
+ */
+export function toUpdateRequest(
+    values: ArticleFormValues,
+    original: Article,
+    targetStatus: ArticleStatus,
+): UpdateArticleRequest {
+    const summary = values.summary.trim();
+    const nextSlug = values.slug.trim();
+
+    const payload: UpdateArticleRequest = {
+        title: values.title.trim(),
+        body: values.body,
+        summary,
+        status: targetStatus,
+        tags: values.tags,
+    };
+
+    if (nextSlug !== original.slug) {
+        payload.newSlug = nextSlug;
+    }
+
+    if (
+        targetStatus === ArticleStatus.Published &&
+        !original.publishedAt
+    ) {
+        payload.publishedAt = new Date().toISOString();
+    }
+
+    return payload;
+}

--- a/src/lib/hooks/useAdminArticles.ts
+++ b/src/lib/hooks/useAdminArticles.ts
@@ -1,0 +1,60 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type {
+    Article,
+    CreateArticleRequest,
+    UpdateArticleRequest,
+} from '@bryandebaun/mcp-client';
+import * as repo from '@/lib/repositories/articlesRepository';
+
+const ARTICLES_KEY = ['admin-articles'];
+
+/**
+ * TanStack Query hook powering the admin articles UI. Fetches all articles
+ * (incl. drafts) and exposes create/update/delete mutations that invalidate the
+ * list on settle so it refreshes after a mutation.
+ */
+export function useAdminArticles(initialArticles?: Article[]) {
+    const qc = useQueryClient();
+
+    const articlesQuery = useQuery({
+        queryKey: ARTICLES_KEY,
+        queryFn: repo.listAdminArticles,
+        initialData: initialArticles,
+    });
+
+    const invalidate = () => {
+        qc.invalidateQueries({ queryKey: ARTICLES_KEY });
+    };
+
+    const createMutation = useMutation({
+        mutationFn: (data: CreateArticleRequest) => repo.createArticle(data),
+        onSettled: invalidate,
+    });
+
+    const updateMutation = useMutation({
+        mutationFn: ({
+            slug,
+            data,
+        }: {
+            slug: string;
+            data: UpdateArticleRequest;
+        }) => repo.updateArticle(slug, data),
+        onSettled: invalidate,
+    });
+
+    const deleteMutation = useMutation({
+        mutationFn: (slug: string) => repo.deleteArticle(slug),
+        onSettled: invalidate,
+    });
+
+    return {
+        articles: articlesQuery.data ?? [],
+        isLoading: articlesQuery.isLoading,
+        isError: articlesQuery.isError,
+        error: articlesQuery.error as Error | null,
+        refetch: articlesQuery.refetch,
+        createMutation,
+        updateMutation,
+        deleteMutation,
+    };
+}

--- a/src/lib/repositories/articlesRepository.ts
+++ b/src/lib/repositories/articlesRepository.ts
@@ -1,0 +1,92 @@
+import type {
+    Article,
+    CreateArticleRequest,
+    UpdateArticleRequest,
+} from '@bryandebaun/mcp-client';
+
+/**
+ * Client-side repository for admin article operations. Talks to the admin API
+ * routes (which enforce auth + send the Supabase JWT and MCP gateway key to the
+ * MCP server). Never calls the MCP server directly — that would leak secrets to
+ * the browser.
+ */
+
+/**
+ * Error carrying per-field validation messages from the admin API (e.g. the
+ * `slug already exists` 400). The editor surfaces these inline.
+ */
+export class ArticleFieldError extends Error {
+    readonly fieldErrors: Record<string, string>;
+    constructor(fieldErrors: Record<string, string>) {
+        super('Validation failed');
+        this.name = 'ArticleFieldError';
+        this.fieldErrors = fieldErrors;
+    }
+}
+
+async function parseFieldError(res: Response): Promise<never> {
+    const data = (await res.json().catch(() => null)) as {
+        fieldErrors?: Record<string, string>;
+        error?: string;
+    } | null;
+    if (data?.fieldErrors) {
+        throw new ArticleFieldError(data.fieldErrors);
+    }
+    throw new Error(data?.error ?? `Request failed: ${res.status}`);
+}
+
+/** Fetch all articles including drafts (admin-only). */
+export async function listAdminArticles(): Promise<Article[]> {
+    const res = await fetch('/api/admin/articles');
+    if (!res.ok) {
+        throw new Error(`Failed to fetch articles: ${res.status}`);
+    }
+    const data = (await res.json()) as { articles: Article[] };
+    return data.articles ?? [];
+}
+
+/** Create a new article. Throws {@link ArticleFieldError} on a slug conflict. */
+export async function createArticle(
+    data: CreateArticleRequest,
+): Promise<Article> {
+    const res = await fetch('/api/admin/articles', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(data),
+    });
+    if (!res.ok) {
+        return parseFieldError(res);
+    }
+    return (await res.json()) as Article;
+}
+
+/** Update an article by slug. Throws {@link ArticleFieldError} on a slug conflict. */
+export async function updateArticle(
+    slug: string,
+    data: UpdateArticleRequest,
+): Promise<Article> {
+    const res = await fetch(`/api/admin/articles/${encodeURIComponent(slug)}`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(data),
+    });
+    if (!res.ok) {
+        return parseFieldError(res);
+    }
+    return (await res.json()) as Article;
+}
+
+/** Delete an article by slug. */
+export async function deleteArticle(slug: string): Promise<void> {
+    const res = await fetch(`/api/admin/articles/${encodeURIComponent(slug)}`, {
+        method: 'DELETE',
+    });
+    if (!res.ok && res.status !== 204) {
+        const data = (await res.json().catch(() => null)) as {
+            error?: string;
+        } | null;
+        throw new Error(
+            data?.error ?? `Failed to delete article: ${res.status}`,
+        );
+    }
+}

--- a/src/lib/services/admin-articles.ts
+++ b/src/lib/services/admin-articles.ts
@@ -1,0 +1,32 @@
+import type { Article } from '@bryandebaun/mcp-client';
+import { ArticleReadStatus } from '@bryandebaun/mcp-client';
+import { createApi } from '@/lib/mcp';
+import { unwrapApiResponse } from '@/lib/api-response';
+import { createClient } from '@/lib/supabase/server';
+
+/**
+ * Server-side fetch of a single article INCLUDING drafts, for the admin editor.
+ *
+ * Sends the caller's Supabase JWT (plus the gateway key, via `createApi`) so the
+ * MCP server authorizes returning unpublished content — exactly the two-factor
+ * path the admin write routes use. Callers must already be behind
+ * `requireAdminPage()`. Returns `null` when missing or unreachable.
+ */
+export async function getAdminArticleBySlug(
+    slug: string,
+): Promise<Article | null> {
+    try {
+        const supabase = await createClient();
+        const {
+            data: { session },
+        } = await supabase.auth.getSession();
+        const api = createApi(session?.access_token);
+        const res = await api.api.getArticle(slug, {
+            status: ArticleReadStatus.All,
+        });
+        return unwrapApiResponse<Article>(res) ?? null;
+    } catch (e) {
+        console.error(`getAdminArticleBySlug(${slug}) failed`, e);
+        return null;
+    }
+}

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,0 +1,13 @@
+/**
+ * Convert arbitrary text into a URL-safe slug: lowercase, ASCII-folded,
+ * non-alphanumerics collapsed to single hyphens, no leading/trailing hyphens.
+ * Used to auto-suggest an article slug from its title.
+ */
+export function slugify(input: string): string {
+    return input
+        .normalize('NFKD')
+        .replace(/[̀-ͯ]/gu, '') // strip diacritics
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/gu, '-')
+        .replace(/^-+|-+$/gu, '');
+}


### PR DESCRIPTION
﻿## Summary

Admin authoring UI for Articles (#88) — completes the articles pipeline (ADR #86, public rendering #87). Stacked on #87; merge that first.

## What's included
- **Admin API routes** (`requireAdmin()` first, then authenticated `createApi(jwt)` — same two-factor path as the books routes; no keys reach the browser):
  - `GET/POST /api/admin/articles`, `PUT/DELETE /api/admin/articles/[slug]`
  - Every write calls `revalidatePath('/philosophy', '/philosophy/<slug>')` so the public site updates immediately (no waiting out ISR).
- **`/admin/articles`** — TanStack-table list of all articles incl. drafts (status pill, dates), with New, publish/unpublish toggle, and delete-with-confirm.
- **`/admin/articles/new` + `/[slug]/edit`** — shared `ArticleEditor`: title, slug (auto-suggested, editable), summary, tags, and a **Markdown body editor with live preview** rendered through the public `ArticleBody` — so preview === published render exactly.
- **Draft → Publish workflow**: publish stamps `publishedAt` (preserved on re-publish); unpublish flips back to draft.
- **Slug-conflict** (API 400) surfaced inline under the slug field.
- **AdminNav**: Articles link. Non-admins are blocked **server-side** (`requireAdminPage`), not just hidden.

## Editor scope
Markdown editor + live-preview pane (not a heavyweight contenteditable WYSIWYG) — guarantees preview parity with the public page and is robust. A richer WYSIWYG can be a follow-up.

## Verification
- `pnpm run lint` clean · `pnpm test` **227 pass** (+32) · `pnpm run build` OK (admin article routes dynamic; builds without the API reachable).

End-to-end smoke (edit the seeded `cptsd`, publish/unpublish round-trip) needs a logged-in admin against the live MCP — unit tests mock the client.

Closes #88.
