### PR TITLE
feat: parlay legs editor + clearer stake in bet form (#100 follow-up)

### DIFF
--- a/src/components/admin/BetForm.tsx
+++ b/src/components/admin/BetForm.tsx
@@ -1,13 +1,23 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import {
     type Bet,
+    type BetLeg,
     type CreateBetRequest,
     BetMarket,
     BetSource,
 } from '@bryandebaun/mcp-client';
 import Select from '@/components/Select';
+
+/** A parlay leg as edited in the form (string-valued inputs + stable key). */
+interface LegInput {
+    id: number;
+    event: string;
+    selection: string;
+    oddsAmerican: string;
+    line: string;
+}
 
 type Props = {
     mode: 'create' | 'edit';
@@ -73,21 +83,98 @@ export default function BetForm({
     );
     const [notes, setNotes] = useState(initialValues?.notes ?? '');
 
+    const legIdRef = useRef(0);
+    const [legs, setLegs] = useState<LegInput[]>(() =>
+        Array.isArray(initialValues?.legs)
+            ? (initialValues?.legs as BetLeg[]).map((l) => ({
+                  id: legIdRef.current++,
+                  event: l.event ?? '',
+                  selection: l.selection ?? '',
+                  oddsAmerican:
+                      l.oddsAmerican != null ? String(l.oddsAmerican) : '',
+                  line: l.line != null ? String(l.line) : '',
+              }))
+            : [],
+    );
+
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
     const isAi = source === BetSource.AI_ASSISTED;
+    const isParlay = market === BetMarket.Parlay;
+
+    const addLeg = () =>
+        setLegs((prev) => [
+            ...prev,
+            {
+                id: legIdRef.current++,
+                event: '',
+                selection: '',
+                oddsAmerican: '',
+                line: '',
+            },
+        ]);
+    const removeLeg = (id: number) =>
+        setLegs((prev) => prev.filter((l) => l.id !== id));
+    const updateLeg = (id: number, key: keyof LegInput, value: string) =>
+        setLegs((prev) =>
+            prev.map((l) => (l.id === id ? { ...l, [key]: value } : l)),
+        );
 
     async function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
         const odds = numOrUndefined(oddsAmerican);
         const stakeNum = numOrUndefined(stake);
-        if (!sport.trim() || !event.trim() || !selection.trim()) {
-            setError('Sport, event, and selection are required.');
+
+        // Parse complete parlay legs (event + selection + valid odds).
+        const parsedLegs: BetLeg[] = legs
+            .map((l) => ({
+                event: l.event.trim(),
+                selection: l.selection.trim(),
+                oddsAmerican: numOrUndefined(l.oddsAmerican),
+                line: numOrUndefined(l.line),
+            }))
+            .filter(
+                (l) => l.event && l.selection && l.oddsAmerican !== undefined,
+            )
+            .map((l) => ({
+                event: l.event,
+                selection: l.selection,
+                oddsAmerican: l.oddsAmerican as number,
+                ...(l.line !== undefined ? { line: l.line } : {}),
+            }));
+
+        // For a parlay, derive event/selection from the legs when left blank so
+        // the user only has to fill the legs + combined odds + total stake.
+        const finalEvent =
+            isParlay && !event.trim() && parsedLegs.length
+                ? `${parsedLegs.length}-leg parlay`
+                : event.trim();
+        const finalSelection =
+            isParlay && !selection.trim() && parsedLegs.length
+                ? parsedLegs.map((l) => l.selection).join(' + ')
+                : selection.trim();
+
+        if (!sport.trim()) {
+            setError('Sport is required.');
+            return;
+        }
+        if (isParlay && parsedLegs.length < 2) {
+            setError(
+                'A parlay needs at least 2 complete legs (event, selection, odds).',
+            );
+            return;
+        }
+        if (!finalEvent || !finalSelection) {
+            setError('Event and selection are required.');
             return;
         }
         if (odds === undefined) {
-            setError('Valid American odds are required.');
+            setError(
+                isParlay
+                    ? 'Combined American odds are required.'
+                    : 'Valid American odds are required.',
+            );
             return;
         }
         if (stakeNum === undefined || stakeNum <= 0) {
@@ -100,15 +187,16 @@ export default function BetForm({
         try {
             const payload: CreateBetRequest = {
                 sport: sport.trim(),
-                event: event.trim(),
+                event: finalEvent,
                 market,
-                selection: selection.trim(),
+                selection: finalSelection,
                 oddsAmerican: odds,
                 stake: stakeNum,
                 source,
                 league: league.trim() || undefined,
-                line: numOrUndefined(line),
+                line: isParlay ? undefined : numOrUndefined(line),
                 book: book.trim() || undefined,
+                legs: isParlay && parsedLegs.length ? parsedLegs : undefined,
                 aiModel: isAi ? aiModel.trim() || undefined : undefined,
                 aiRationale: isAi ? aiRationale.trim() || undefined : undefined,
                 aiEstProb: isAi ? numOrUndefined(aiEstProb) : undefined,
@@ -274,29 +362,31 @@ export default function BetForm({
                         </div>
                     </div>
 
-                    <div className="grid grid-cols-3 gap-3">
-                        <div>
-                            <label
-                                htmlFor="bet-line"
-                                className="block text-sm font-medium"
-                            >
-                                Line
-                            </label>
-                            <input
-                                id="bet-line"
-                                type="number"
-                                step="any"
-                                className="mt-1 w-full form-input"
-                                value={line}
-                                onChange={(e) => setLine(e.target.value)}
-                            />
-                        </div>
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                        {!isParlay ? (
+                            <div>
+                                <label
+                                    htmlFor="bet-line"
+                                    className="block text-sm font-medium"
+                                >
+                                    Line
+                                </label>
+                                <input
+                                    id="bet-line"
+                                    type="number"
+                                    step="any"
+                                    className="mt-1 w-full form-input"
+                                    value={line}
+                                    onChange={(e) => setLine(e.target.value)}
+                                />
+                            </div>
+                        ) : null}
                         <div>
                             <label
                                 htmlFor="bet-odds"
                                 className="block text-sm font-medium"
                             >
-                                Odds (US){' '}
+                                {isParlay ? 'Combined odds (US)' : 'Odds (US)'}{' '}
                                 <span
                                     className="text-red-500"
                                     aria-hidden="true"
@@ -313,7 +403,7 @@ export default function BetForm({
                                 onChange={(e) =>
                                     setOddsAmerican(e.target.value)
                                 }
-                                placeholder="-110"
+                                placeholder={isParlay ? '+650' : '-110'}
                                 required
                             />
                         </div>
@@ -322,7 +412,7 @@ export default function BetForm({
                                 htmlFor="bet-stake"
                                 className="block text-sm font-medium"
                             >
-                                Stake{' '}
+                                Stake ($){' '}
                                 <span
                                     className="text-red-500"
                                     aria-hidden="true"
@@ -338,10 +428,143 @@ export default function BetForm({
                                 className="mt-1 w-full form-input"
                                 value={stake}
                                 onChange={(e) => setStake(e.target.value)}
+                                placeholder="25.00"
                                 required
                             />
                         </div>
                     </div>
+
+                    {isParlay ? (
+                        <fieldset className="rounded-md border border-[var(--color-norwegian-300)] dark:border-[var(--color-norwegian-600)] p-3 space-y-3">
+                            <legend className="px-1 text-sm font-medium">
+                                Parlay legs
+                            </legend>
+                            <p className="text-xs text-[var(--color-norwegian-600)] dark:text-[var(--color-norwegian-300)]">
+                                Add each leg below. Put the combined odds and
+                                total stake in the fields above; event/selection
+                                auto-fill from the legs if left blank.
+                            </p>
+                            {legs.length === 0 ? (
+                                <p className="text-sm text-[var(--color-norwegian-600)] dark:text-[var(--color-norwegian-300)]">
+                                    No legs yet.
+                                </p>
+                            ) : null}
+                            {legs.map((leg, idx) => (
+                                <div
+                                    key={leg.id}
+                                    className="grid grid-cols-1 sm:grid-cols-12 gap-2 items-end"
+                                >
+                                    <div className="sm:col-span-4">
+                                        <label
+                                            htmlFor={`leg-event-${leg.id}`}
+                                            className="block text-xs font-medium"
+                                        >
+                                            Event
+                                        </label>
+                                        <input
+                                            id={`leg-event-${leg.id}`}
+                                            type="text"
+                                            className="mt-1 w-full form-input"
+                                            placeholder="Portugal vs Croatia"
+                                            value={leg.event}
+                                            onChange={(e) =>
+                                                updateLeg(
+                                                    leg.id,
+                                                    'event',
+                                                    e.target.value,
+                                                )
+                                            }
+                                        />
+                                    </div>
+                                    <div className="sm:col-span-3">
+                                        <label
+                                            htmlFor={`leg-sel-${leg.id}`}
+                                            className="block text-xs font-medium"
+                                        >
+                                            Selection
+                                        </label>
+                                        <input
+                                            id={`leg-sel-${leg.id}`}
+                                            type="text"
+                                            className="mt-1 w-full form-input"
+                                            placeholder="Croatia ML"
+                                            value={leg.selection}
+                                            onChange={(e) =>
+                                                updateLeg(
+                                                    leg.id,
+                                                    'selection',
+                                                    e.target.value,
+                                                )
+                                            }
+                                        />
+                                    </div>
+                                    <div className="sm:col-span-2">
+                                        <label
+                                            htmlFor={`leg-odds-${leg.id}`}
+                                            className="block text-xs font-medium"
+                                        >
+                                            Odds
+                                        </label>
+                                        <input
+                                            id={`leg-odds-${leg.id}`}
+                                            type="number"
+                                            step="1"
+                                            className="mt-1 w-full form-input"
+                                            placeholder="+370"
+                                            value={leg.oddsAmerican}
+                                            onChange={(e) =>
+                                                updateLeg(
+                                                    leg.id,
+                                                    'oddsAmerican',
+                                                    e.target.value,
+                                                )
+                                            }
+                                        />
+                                    </div>
+                                    <div className="sm:col-span-2">
+                                        <label
+                                            htmlFor={`leg-line-${leg.id}`}
+                                            className="block text-xs font-medium"
+                                        >
+                                            Line
+                                        </label>
+                                        <input
+                                            id={`leg-line-${leg.id}`}
+                                            type="number"
+                                            step="any"
+                                            className="mt-1 w-full form-input"
+                                            placeholder="—"
+                                            value={leg.line}
+                                            onChange={(e) =>
+                                                updateLeg(
+                                                    leg.id,
+                                                    'line',
+                                                    e.target.value,
+                                                )
+                                            }
+                                        />
+                                    </div>
+                                    <div className="sm:col-span-1">
+                                        <button
+                                            type="button"
+                                            onClick={() => removeLeg(leg.id)}
+                                            aria-label={`Remove leg ${idx + 1}`}
+                                            className="btn w-full"
+                                        >
+                                            ✕
+                                        </button>
+                                    </div>
+                                </div>
+                            ))}
+                            <button
+                                type="button"
+                                onClick={addLeg}
+                                className="btn"
+                            >
+                                + Add leg
+                            </button>
+                        </fieldset>
+                    ) : null}
 
                     <div>
                         <label

--- a/src/components/admin/BetForm.tsx
+++ b/src/components/admin/BetForm.tsx
@@ -302,9 +302,18 @@ export default function BetForm({
                             className="block text-sm font-medium"
                         >
                             Event{' '}
-                            <span className="text-red-500" aria-hidden="true">
-                                *
-                            </span>
+                            {isParlay ? (
+                                <span className="text-[var(--color-norwegian-500)] font-normal">
+                                    (auto from legs)
+                                </span>
+                            ) : (
+                                <span
+                                    className="text-red-500"
+                                    aria-hidden="true"
+                                >
+                                    *
+                                </span>
+                            )}
                         </label>
                         <input
                             id="bet-event"
@@ -312,7 +321,10 @@ export default function BetForm({
                             className="mt-1 w-full form-input"
                             value={event}
                             onChange={(e) => setEvent(e.target.value)}
-                            required
+                            placeholder={
+                                isParlay ? 'e.g. World Cup 4-leg parlay' : ''
+                            }
+                            required={!isParlay}
                         />
                     </div>
 
@@ -344,12 +356,18 @@ export default function BetForm({
                                 className="block text-sm font-medium"
                             >
                                 Selection{' '}
-                                <span
-                                    className="text-red-500"
-                                    aria-hidden="true"
-                                >
-                                    *
-                                </span>
+                                {isParlay ? (
+                                    <span className="text-[var(--color-norwegian-500)] font-normal">
+                                        (auto)
+                                    </span>
+                                ) : (
+                                    <span
+                                        className="text-red-500"
+                                        aria-hidden="true"
+                                    >
+                                        *
+                                    </span>
+                                )}
                             </label>
                             <input
                                 id="bet-selection"
@@ -357,7 +375,7 @@ export default function BetForm({
                                 className="mt-1 w-full form-input"
                                 value={selection}
                                 onChange={(e) => setSelection(e.target.value)}
-                                required
+                                required={!isParlay}
                             />
                         </div>
                     </div>

--- a/src/components/admin/BetForm.tsx
+++ b/src/components/admin/BetForm.tsx
@@ -9,7 +9,7 @@ import {
     BetSource,
 } from '@bryandebaun/mcp-client';
 import Select from '@/components/Select';
-import { MARKET_OPTIONS, SPORT_OPTIONS } from '@/lib/bets';
+import { BOOK_OPTIONS, MARKET_OPTIONS, SPORT_OPTIONS } from '@/lib/bets';
 
 /** A parlay leg as edited in the form (string-valued inputs + stable key). */
 interface LegInput {
@@ -58,7 +58,7 @@ export default function BetForm({
     const [stake, setStake] = useState(
         initialValues?.stake != null ? String(initialValues.stake) : '',
     );
-    const [book, setBook] = useState(initialValues?.book ?? '');
+    const [book, setBook] = useState(initialValues?.book ?? 'DraftKings');
     const [source, setSource] = useState<BetSource>(
         (initialValues?.source as BetSource) ?? BetSource.INTUITION,
     );
@@ -101,6 +101,10 @@ export default function BetForm({
         sport && !SPORT_OPTIONS.some((o) => o.value === sport)
             ? [{ value: sport, label: sport }, ...SPORT_OPTIONS]
             : SPORT_OPTIONS;
+    const bookOptions =
+        book && !BOOK_OPTIONS.some((o) => o.value === book)
+            ? [{ value: book, label: book }, ...BOOK_OPTIONS]
+            : BOOK_OPTIONS;
 
     const addLeg = () =>
         setLegs((prev) => [
@@ -605,12 +609,14 @@ export default function BetForm({
                         >
                             Book
                         </label>
-                        <input
+                        <Select
                             id="bet-book"
-                            type="text"
-                            className="mt-1 w-full form-input"
+                            ariaLabel="Book"
+                            className="mt-1"
+                            placeholder="Select book"
                             value={book ?? ''}
-                            onChange={(e) => setBook(e.target.value)}
+                            onValueChange={setBook}
+                            options={bookOptions}
                         />
                     </div>
 

--- a/src/components/admin/BetForm.tsx
+++ b/src/components/admin/BetForm.tsx
@@ -9,6 +9,7 @@ import {
     BetSource,
 } from '@bryandebaun/mcp-client';
 import Select from '@/components/Select';
+import { MARKET_OPTIONS, SPORT_OPTIONS } from '@/lib/bets';
 
 /** A parlay leg as edited in the form (string-valued inputs + stable key). */
 interface LegInput {
@@ -25,14 +26,6 @@ type Props = {
     onSubmit: (data: CreateBetRequest) => Promise<void>;
     onCancel: () => void;
 };
-
-const MARKET_OPTIONS: { value: BetMarket; label: string }[] = [
-    { value: BetMarket.Moneyline, label: 'Moneyline' },
-    { value: BetMarket.Spread, label: 'Spread' },
-    { value: BetMarket.Total, label: 'Total' },
-    { value: BetMarket.Prop, label: 'Prop' },
-    { value: BetMarket.Parlay, label: 'Parlay' },
-];
 
 /** Parse a numeric input into a number, or undefined when blank/invalid. */
 function numOrUndefined(value: string): number | undefined {
@@ -102,6 +95,12 @@ export default function BetForm({
 
     const isAi = source === BetSource.AI_ASSISTED;
     const isParlay = market === BetMarket.Parlay;
+
+    // Keep an off-list sport (e.g. from an older bet) selectable when editing.
+    const sportOptions =
+        sport && !SPORT_OPTIONS.some((o) => o.value === sport)
+            ? [{ value: sport, label: sport }, ...SPORT_OPTIONS]
+            : SPORT_OPTIONS;
 
     const addLeg = () =>
         setLegs((prev) => [
@@ -270,13 +269,14 @@ export default function BetForm({
                                     *
                                 </span>
                             </label>
-                            <input
+                            <Select
                                 id="bet-sport"
-                                type="text"
-                                className="mt-1 w-full form-input"
+                                ariaLabel="Sport"
+                                className="mt-1"
+                                placeholder="Select sport"
                                 value={sport}
-                                onChange={(e) => setSport(e.target.value)}
-                                required
+                                onValueChange={setSport}
+                                options={sportOptions}
                             />
                         </div>
                         <div>

--- a/src/components/admin/BetForm.tsx
+++ b/src/components/admin/BetForm.tsx
@@ -158,9 +158,20 @@ export default function BetForm({
             setError('Sport is required.');
             return;
         }
-        if (isParlay && parsedLegs.length < 2) {
+        // Legs are optional for a parlay — same-game parlays often don't expose
+        // per-leg odds. But if any leg fields are started, require >=2 complete
+        // legs (the backend requires odds per leg) so we never store half-entered
+        // legs.
+        const hasLegInput = legs.some(
+            (l) =>
+                l.event.trim() ||
+                l.selection.trim() ||
+                l.oddsAmerican.trim() ||
+                l.line.trim(),
+        );
+        if (isParlay && hasLegInput && parsedLegs.length < 2) {
             setError(
-                'A parlay needs at least 2 complete legs (event, selection, odds).',
+                'For parlay legs, complete at least 2 (each needs event, selection, odds) or clear them.',
             );
             return;
         }
@@ -458,9 +469,12 @@ export default function BetForm({
                                 Parlay legs
                             </legend>
                             <p className="text-xs text-[var(--color-norwegian-600)] dark:text-[var(--color-norwegian-300)]">
-                                Add each leg below. Put the combined odds and
-                                total stake in the fields above; event/selection
-                                auto-fill from the legs if left blank.
+                                Legs are optional — same-game parlays often
+                                don&apos;t show per-leg odds. If your book lists
+                                each price, add 2+ legs; otherwise just set the
+                                combined odds + total stake above and note the
+                                selections. Per-leg Line is only for
+                                totals/spreads (e.g. Over 2.5 → 2.5).
                             </p>
                             {legs.length === 0 ? (
                                 <p className="text-sm text-[var(--color-norwegian-600)] dark:text-[var(--color-norwegian-300)]">

--- a/src/components/admin/BetsAdmin.tsx
+++ b/src/components/admin/BetsAdmin.tsx
@@ -6,7 +6,6 @@ import {
     type Bet,
     type CreateBetRequest,
     type SettleBetRequest,
-    BetMarket,
     BetSource,
     BetStatus,
 } from '@bryandebaun/mcp-client';
@@ -17,11 +16,14 @@ import BetAnalyticsPanel from '@/components/admin/BetAnalyticsPanel';
 import { useAdminBets } from '@/lib/hooks/useAdminBets';
 import {
     type BetFilters,
+    MARKET_OPTIONS,
+    SPORT_OPTIONS,
     clvPercent,
     formatAmericanOdds,
     formatBetDate,
     formatClvPercent,
     formatCurrency,
+    marketLabel,
 } from '@/lib/bets';
 
 const SETTLE_OPTIONS: SettleBetRequest['status'][] = [
@@ -197,7 +199,7 @@ export default function BetsAdmin(_props: Props) {
                 id: 'market',
                 header: 'Market',
                 cell: (info: CellContext<Bet, unknown>) =>
-                    info.row.original.market,
+                    marketLabel(info.row.original.market),
             },
             {
                 id: 'selection',
@@ -371,10 +373,7 @@ export default function BetsAdmin(_props: Props) {
                         onValueChange={(v) => setFilter('market', v)}
                         options={[
                             { value: '', label: 'All' },
-                            ...Object.values(BetMarket).map((m) => ({
-                                value: m,
-                                label: m,
-                            })),
+                            ...MARKET_OPTIONS,
                         ]}
                     />
                 </div>
@@ -382,13 +381,12 @@ export default function BetsAdmin(_props: Props) {
                     <label htmlFor="filter-sport" className="text-sm mb-1">
                         Sport
                     </label>
-                    <input
+                    <Select
                         id="filter-sport"
-                        type="text"
-                        className="form-input w-full"
-                        placeholder="All"
+                        ariaLabel="Sport"
                         value={filters.sport ?? ''}
-                        onChange={(e) => setFilter('sport', e.target.value)}
+                        onValueChange={(v) => setFilter('sport', v)}
+                        options={[{ value: '', label: 'All' }, ...SPORT_OPTIONS]}
                     />
                 </div>
                 <div className="flex flex-col w-44">

--- a/src/lib/bets.ts
+++ b/src/lib/bets.ts
@@ -43,6 +43,20 @@ export const SPORT_OPTIONS: { value: string; label: string }[] = [
 ];
 
 /**
+ * Sportsbooks offered in the bet UI. `Bet.book` is free-text in the DB (the
+ * server defaults it to "DraftKings"), so this is a curated frontend list — add
+ * an entry to support another book. The first entry is the form default.
+ */
+export const BOOK_OPTIONS: { value: string; label: string }[] = [
+    { value: 'DraftKings', label: 'DraftKings' },
+    { value: 'FanDuel', label: 'FanDuel' },
+    { value: 'BetMGM', label: 'BetMGM' },
+    { value: 'Caesars', label: 'Caesars' },
+    { value: 'ESPN BET', label: 'ESPN BET' },
+    { value: 'Fanatics', label: 'Fanatics' },
+];
+
+/**
  * Pure, side-effect-free formatting and derivation helpers for the admin Bets
  * dashboard. Everything here is unit-testable and performs no I/O — UI
  * components and route handlers import these so display logic stays consistent

--- a/src/lib/bets.ts
+++ b/src/lib/bets.ts
@@ -1,11 +1,46 @@
-import type {
-    Bet,
-    BetLeg,
-    BetMetrics,
+import {
+    type Bet,
+    type BetLeg,
+    type BetMetrics,
     BetMarket,
-    BetSource,
-    BetStatus,
+    type BetSource,
+    type BetStatus,
 } from '@bryandebaun/mcp-client';
+
+/**
+ * Market options with display labels. The `BetMarket` enum values are lowercase
+ * (`moneyline`, `parlay`, …); these labels are the capitalized display form,
+ * shared by the form and the filters so they stay consistent.
+ */
+export const MARKET_OPTIONS: { value: BetMarket; label: string }[] = [
+    { value: BetMarket.Moneyline, label: 'Moneyline' },
+    { value: BetMarket.Spread, label: 'Spread' },
+    { value: BetMarket.Total, label: 'Total' },
+    { value: BetMarket.Prop, label: 'Prop' },
+    { value: BetMarket.Parlay, label: 'Parlay' },
+];
+
+const MARKET_LABELS = Object.fromEntries(
+    MARKET_OPTIONS.map((m) => [m.value, m.label]),
+) as Record<BetMarket, string>;
+
+/** Capitalized display label for a market value; falls back to the raw value. */
+export function marketLabel(
+    value: BetMarket | string | null | undefined,
+): string {
+    if (!value) return '—';
+    return MARKET_LABELS[value as BetMarket] ?? String(value);
+}
+
+/**
+ * Sports offered in the bet UI. `Bet.sport` is free-text in the DB, so this is a
+ * curated frontend list — add an entry here to support a new sport (no
+ * migration needed). Values are stored verbatim, so keep them stable.
+ */
+export const SPORT_OPTIONS: { value: string; label: string }[] = [
+    { value: 'Soccer', label: 'Soccer (Intl. Football)' },
+    { value: 'American Football', label: 'American Football' },
+];
 
 /**
  * Pure, side-effect-free formatting and derivation helpers for the admin Bets


### PR DESCRIPTION
﻿## Summary

Follow-up to #100 — addresses two gaps in the Log/Edit Bet form surfaced while logging a real DraftKings parlay: no way to enter parlay **legs**, and cramped stake entry.

## Changes
- **Parlay legs editor**: when Market = Parlay, a repeatable "Parlay legs" section appears — each leg has event, selection, odds, and optional line, with add/remove. Wired into `CreateBetRequest.legs`.
- **Smarter parlay fields**: the top-level event/selection **auto-derive from the legs** when left blank (`"N-leg parlay"` + joined selections); the Odds field is relabeled **"Combined odds"** and the per-bet Line is hidden (lines are per-leg). Requires ≥2 complete legs.
- **Clearer stake**: odds/stake row is now responsive (stacks on mobile), with a `Stake ($)` label + placeholder.

## Verification
- `pnpm run lint` clean · `pnpm test` 268 pass · `pnpm run build` OK.

Closes the parlay-entry gap from #100; complements the AI-assisted authoring tracked in #104.
