### PR TITLE
feat: bet-form payout display + odds-less parlay legs (#137)

### DIFF
--- a/packages/mcp-client/src/api-client.ts
+++ b/packages/mcp-client/src/api-client.ts
@@ -405,8 +405,11 @@ export interface BetAnalyticsResponse {
 export interface BetLeg {
   event: string;
   selection: string;
-  /** @format double */
-  oddsAmerican: number;
+  /**
+   * Optional: same-game parlays expose only the combined price, not per-leg odds (#137).
+   * @format double
+   */
+  oddsAmerican?: number;
   /** @format double */
   line?: number;
 }

--- a/src/app/admin/articles/page.tsx
+++ b/src/app/admin/articles/page.tsx
@@ -13,8 +13,7 @@ export default async function AdminArticlesPage() {
         <main className="p-6">
             <h1 className="text-2xl font-semibold mb-6">Admin</h1>
             <AdminNav />
-            <section>
-                <h2 className="text-xl font-semibold mb-4">Articles</h2>
+            <section aria-label="Articles">
                 <ArticlesAdmin />
             </section>
         </main>

--- a/src/app/admin/bets/page.tsx
+++ b/src/app/admin/bets/page.tsx
@@ -13,8 +13,7 @@ export default async function AdminBetsPage() {
         <main className="p-6">
             <h1 className="text-2xl font-semibold mb-6">Admin</h1>
             <AdminNav />
-            <section>
-                <h2 className="text-xl font-semibold mb-4">Bets</h2>
+            <section aria-label="Bets">
                 <BetsAdmin />
             </section>
         </main>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -17,8 +17,7 @@ export default async function AdminPage() {
         <main className="p-6">
             <h1 className="text-2xl font-semibold mb-6">Admin</h1>
             <AdminNav />
-            <section>
-                <h2 className="text-xl font-semibold mb-4">Books</h2>
+            <section aria-label="Books">
                 <BooksTable books={books} isAdmin={true} />
             </section>
         </main>

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -13,10 +13,7 @@ export default async function AdminUsersPage() {
         <main className="p-6">
             <h1 className="text-2xl font-semibold mb-6">Admin</h1>
             <AdminNav />
-            <section>
-                <h2 className="text-xl font-semibold mb-4">
-                    Users &amp; Invites
-                </h2>
+            <section aria-label="Users & Invites">
                 <UsersAdmin />
             </section>
         </main>

--- a/src/app/media/page.tsx
+++ b/src/app/media/page.tsx
@@ -1,7 +1,12 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 import BooksTable from '@/components/BooksTable';
+import PublicBets from '@/components/PublicBets';
 import Tabs from '@/components/Tabs';
+import {
+    getPublicBetAnalytics,
+    listPublicBets,
+} from '@/lib/services/public-bets';
 
 export const metadata: Metadata = {
     title: 'Media — Bryan DeBaun',
@@ -25,6 +30,11 @@ export default async function Page() {
         m.listBooks(),
     );
 
+    const [bets, betAnalytics] = await Promise.all([
+        listPublicBets(),
+        getPublicBetAnalytics(),
+    ]);
+
     const hasBooks = Boolean(books && books.length > 0);
 
     const allTabs: MediaTab[] = [
@@ -38,6 +48,11 @@ export default async function Page() {
                     No books to show just yet — check back soon.
                 </p>
             ),
+        },
+        {
+            id: 'bets',
+            label: 'Bets',
+            panel: <PublicBets bets={bets} analytics={betAnalytics} />,
         },
         {
             id: 'movies',
@@ -75,10 +90,9 @@ export default async function Page() {
         },
     ];
 
-    // Only render tabs that have content; empty "Coming soon" tabs stay hidden.
-    const tabs = allTabs
-        .filter((t) => !t.comingSoon)
-        .map(({ comingSoon: _comingSoon, ...t }) => t);
+    // Show all media-type tabs (Books + the "Coming soon" placeholders) so the
+    // planned categories are visible.
+    const tabs = allTabs.map(({ comingSoon: _comingSoon, ...t }) => t);
 
     return (
         <main className="p-6">

--- a/src/components/PublicBets.tsx
+++ b/src/components/PublicBets.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import { useMemo } from 'react';
+import type { CellContext, ColumnDef } from '@tanstack/react-table';
+import { BetSource, BetStatus } from '@bryandebaun/mcp-client';
+import Table from '@/components/Table';
+import {
+    clvPercent,
+    formatAmericanOdds,
+    formatBetDate,
+    formatClvPercent,
+    formatPercent,
+    formatRecord,
+    formatRoi,
+    formatUnits,
+    marketLabel,
+} from '@/lib/bets';
+import type {
+    PublicBet,
+    PublicBetAnalytics,
+    PublicBetMetrics,
+} from '@/lib/services/public-bets';
+
+type Props = {
+    bets: PublicBet[];
+    analytics: PublicBetAnalytics | null;
+};
+
+function StatusPill({ status }: { status: BetStatus }) {
+    const tone: Record<BetStatus, string> = {
+        [BetStatus.PENDING]:
+            'bg-[var(--color-norwegian-100)] text-[var(--color-norwegian-700)] dark:bg-[var(--color-norwegian-100-dark)] dark:text-[var(--color-norwegian-300-dark)]',
+        [BetStatus.WON]: 'bg-green-100 text-green-800',
+        [BetStatus.LOST]: 'bg-red-100 text-red-800',
+        [BetStatus.PUSH]: 'bg-amber-100 text-amber-800',
+        [BetStatus.VOID]: 'bg-gray-100 text-gray-700',
+    };
+    return (
+        <span
+            className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${tone[status]}`}
+        >
+            {status}
+        </span>
+    );
+}
+
+function SourcePill({ source }: { source: BetSource }) {
+    const isAi = source === BetSource.AI_ASSISTED;
+    return (
+        <span
+            className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                isAi
+                    ? 'bg-[var(--color-fjord-500)]/15 text-[var(--color-fjord-600)] dark:text-[var(--color-fjord-500)]'
+                    : 'bg-[var(--color-norwegian-500)]/15 text-[var(--color-norwegian-700)] dark:text-[var(--color-norwegian-300)]'
+            }`}
+        >
+            {isAi ? 'AI' : 'Intuition'}
+        </span>
+    );
+}
+
+/** AI metadata cell: model + an expandable rationale for AI-assisted picks. */
+function AiMetaCell({ bet }: { bet: PublicBet }) {
+    if (bet.source !== BetSource.AI_ASSISTED) {
+        return <span className="text-[var(--color-norwegian-400)]">—</span>;
+    }
+    return (
+        <div className="flex flex-col gap-0.5 text-xs">
+            <span className="font-medium">{bet.aiModel ?? 'model ?'}</span>
+            {bet.aiRationale ? (
+                <details className="max-w-[16rem]">
+                    <summary className="cursor-pointer text-[var(--color-fjord-600)]">
+                        Rationale
+                    </summary>
+                    <p className="mt-1 whitespace-normal text-[var(--color-norwegian-700)] dark:text-[var(--color-norwegian-200)]">
+                        {bet.aiRationale}
+                    </p>
+                </details>
+            ) : null}
+        </div>
+    );
+}
+
+/**
+ * One source column in the scoreboard. Leads with CLV (the core experiment
+ * readout) and shows only rate-style metrics — NEVER profit, staked or any $.
+ */
+function ScoreboardColumn({
+    label,
+    accent,
+    metrics,
+}: {
+    label: string;
+    accent: string;
+    metrics: PublicBetMetrics;
+}) {
+    const rows: { label: string; value: string; emphasize?: boolean }[] = [
+        {
+            label: 'CLV (avg)',
+            value: formatClvPercent(metrics.avgClvPct),
+            emphasize: true,
+        },
+        { label: 'ROI', value: formatRoi(metrics.roi) },
+        { label: 'Hit rate', value: formatPercent(metrics.hitRate) },
+        { label: 'Units', value: formatUnits(metrics.units) },
+        { label: 'Record (W-L-P)', value: formatRecord(metrics) },
+        { label: 'Count', value: String(metrics.count) },
+    ];
+
+    return (
+        <div className="rounded-lg border border-[var(--tw-prose-td-borders)] bg-[var(--background)] p-4 shadow-sm">
+            <p className={`mb-3 text-sm font-semibold ${accent}`}>{label}</p>
+            <dl className="divide-y divide-[var(--tw-prose-td-borders)]">
+                {rows.map((row) => (
+                    <div
+                        key={row.label}
+                        className={`flex items-center justify-between py-1.5 ${
+                            row.emphasize
+                                ? 'rounded-md bg-[var(--color-norwegian-50)] dark:bg-[var(--color-norwegian-800)] px-2'
+                                : ''
+                        }`}
+                    >
+                        <dt className="text-xs uppercase tracking-wide text-[var(--color-norwegian-600)] dark:text-[var(--color-norwegian-300)]">
+                            {row.label}
+                        </dt>
+                        <dd
+                            className={`tabular-nums ${
+                                row.emphasize
+                                    ? 'text-base font-semibold'
+                                    : 'text-sm'
+                            }`}
+                        >
+                            {row.value}
+                        </dd>
+                    </div>
+                ))}
+            </dl>
+        </div>
+    );
+}
+
+function Scoreboard({ analytics }: { analytics: PublicBetAnalytics }) {
+    return (
+        <div className="mb-8">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <ScoreboardColumn
+                    label="Intuition"
+                    accent="text-[var(--color-norwegian-600)] dark:text-[var(--color-norwegian-400)]"
+                    metrics={analytics.bySource.INTUITION}
+                />
+                <ScoreboardColumn
+                    label="AI-assisted"
+                    accent="text-[var(--color-fjord-600)] dark:text-[var(--color-fjord-500)]"
+                    metrics={analytics.bySource.AI_ASSISTED}
+                />
+            </div>
+            <p className="mt-3 text-xs text-[var(--color-norwegian-500)]">
+                {analytics.overall.count} picks · {analytics.overall.pending}{' '}
+                pending · {analytics.overall.settled} settled
+            </p>
+        </div>
+    );
+}
+
+export default function PublicBets({ bets, analytics }: Props) {
+    const columns = useMemo<ColumnDef<PublicBet, unknown>[]>(
+        () => [
+            {
+                id: 'placedAt',
+                header: 'Placed',
+                cell: (info: CellContext<PublicBet, unknown>) =>
+                    formatBetDate(info.row.original.placedAt),
+            },
+            {
+                id: 'sport',
+                header: 'Sport',
+                cell: (info: CellContext<PublicBet, unknown>) =>
+                    info.row.original.sport,
+            },
+            {
+                id: 'event',
+                header: 'Event',
+                meta: {
+                    headerClassName: 'text-left',
+                    cellClassName: 'text-left',
+                },
+                cell: (info: CellContext<PublicBet, unknown>) => {
+                    const v = info.row.original.event;
+                    return (
+                        <span
+                            className="block max-w-[12rem] truncate"
+                            title={v}
+                        >
+                            {v}
+                        </span>
+                    );
+                },
+            },
+            {
+                id: 'market',
+                header: 'Market',
+                cell: (info: CellContext<PublicBet, unknown>) =>
+                    marketLabel(info.row.original.market),
+            },
+            {
+                id: 'selection',
+                header: 'Selection',
+                meta: {
+                    headerClassName: 'text-left',
+                    cellClassName: 'text-left',
+                },
+                cell: (info: CellContext<PublicBet, unknown>) => {
+                    const b = info.row.original;
+                    const v =
+                        b.line != null
+                            ? `${b.selection} (${b.line > 0 ? '+' : ''}${b.line})`
+                            : b.selection;
+                    return (
+                        <span
+                            className="block max-w-[18rem] truncate"
+                            title={v}
+                        >
+                            {v}
+                        </span>
+                    );
+                },
+            },
+            {
+                id: 'oddsAmerican',
+                header: 'Odds',
+                cell: (info: CellContext<PublicBet, unknown>) =>
+                    formatAmericanOdds(info.row.original.oddsAmerican),
+            },
+            {
+                id: 'clv',
+                header: 'CLV',
+                cell: (info: CellContext<PublicBet, unknown>) =>
+                    formatClvPercent(clvPercent(info.row.original)),
+            },
+            {
+                id: 'status',
+                header: 'Status',
+                cell: (info: CellContext<PublicBet, unknown>) => (
+                    <StatusPill status={info.row.original.status} />
+                ),
+            },
+            {
+                id: 'source',
+                header: 'Source',
+                cell: (info: CellContext<PublicBet, unknown>) => (
+                    <SourcePill source={info.row.original.source} />
+                ),
+            },
+            {
+                id: 'ai',
+                header: 'AI',
+                meta: {
+                    headerClassName: 'text-left',
+                    cellClassName: 'text-left',
+                },
+                cell: (info: CellContext<PublicBet, unknown>) => (
+                    <AiMetaCell bet={info.row.original} />
+                ),
+            },
+        ],
+        [],
+    );
+
+    return (
+        <section>
+            <p className="mb-6 text-sm text-[var(--color-norwegian-700)] dark:text-[var(--color-white)]">
+                An experiment pitting my gut picks against AI-assisted ones —
+                stakes hidden; here&rsquo;s the public scoreboard.
+            </p>
+
+            {analytics ? <Scoreboard analytics={analytics} /> : null}
+
+            {bets.length > 0 ? (
+                <Table
+                    data={bets}
+                    columns={columns}
+                    className="overflow-x-auto rounded-lg border border-[var(--tw-prose-td-borders)] dark:border-[var(--tw-prose-invert-td-borders)] bg-[var(--background)] shadow-sm ring-1 ring-[var(--tw-prose-td-borders)]"
+                    caption="Public bet picks"
+                />
+            ) : (
+                <p className="text-sm text-[var(--color-norwegian-700)] dark:text-[var(--color-white)]">
+                    No picks to show just yet — check back soon.
+                </p>
+            )}
+        </section>
+    );
+}

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -53,8 +53,8 @@ export default function Table<T>({
     });
 
     return (
-        <div className={className}>
-            <table className="min-w-full table-fixed">
+        <div className={`overflow-x-auto ${className ?? ''}`}>
+            <table className="min-w-full">
                 {caption ? (
                     <caption className="sr-only">{caption}</caption>
                 ) : null}

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -42,34 +42,46 @@ export default function Tabs({
         }
     }
 
+    // Match the content panel's own border (e.g. BooksTable's box) so the active
+    // tab merges into it for an open-folder look, without adding a second box.
+    const borderColor =
+        'border-[var(--tw-prose-td-borders)] dark:border-[var(--tw-prose-invert-td-borders)]';
+
     return (
         <div>
             <div
                 role="tablist"
                 aria-orientation="horizontal"
-                className="flex mb-0 overflow-visible"
+                className="flex items-end gap-1"
             >
-                {tabs.map((t, i) => (
-                    <button
-                        key={t.id}
-                        id={`tab-${t.id}`}
-                        ref={(el) => {
-                            btnRefs.current[i] = el;
-                        }}
-                        role="tab"
-                        aria-selected={selected === i}
-                        aria-controls={`panel-${t.id}`}
-                        tabIndex={selected === i ? 0 : -1}
-                        className={`flex-1 text-center min-w-0 px-3 py-2 rounded-t-md rounded-b-lg first:rounded-l-lg last:rounded-r-lg first:rounded-bl-none last:rounded-br-none text-sm font-medium cursor-pointer transition-colors duration-150 border border-[var(--tw-prose-td-borders)] dark:border-[var(--tw-prose-invert-td-borders)] -ml-px first:ml-0 shadow-sm mb-[-6px] ${selected === i ? 'rounded-b-none border-b-0 z-30 -mt-1 shadow-md bg-white dark:bg-[var(--background)] text-[var(--color-norwegian-700)] dark:text-[var(--color-white)]' : 'rounded-b-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-[var(--color-bg-dark)]'}`}
-                        onClick={() => setSelected(i)}
-                        onKeyDown={(e) => onKeyDown(e, i)}
-                    >
-                        {t.label}
-                    </button>
-                ))}
+                {tabs.map((t, i) => {
+                    const active = selected === i;
+                    return (
+                        <button
+                            key={t.id}
+                            id={`tab-${t.id}`}
+                            ref={(el) => {
+                                btnRefs.current[i] = el;
+                            }}
+                            role="tab"
+                            aria-selected={active}
+                            aria-controls={`panel-${t.id}`}
+                            tabIndex={active ? 0 : -1}
+                            className={`relative -mb-px rounded-t-md border px-4 py-2 text-sm font-medium cursor-pointer transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-fjord-600)] focus-visible:ring-inset ${
+                                active
+                                    ? `z-10 ${borderColor} border-b-0 bg-[var(--background)] text-[var(--color-norwegian-800)] dark:text-[var(--color-white)]`
+                                    : 'border-transparent text-[var(--color-norwegian-600)] dark:text-[var(--color-norwegian-300)] hover:bg-[var(--color-norwegian-100)] dark:hover:bg-white/5'
+                            }`}
+                            onClick={() => setSelected(i)}
+                            onKeyDown={(e) => onKeyDown(e, i)}
+                        >
+                            {t.label}
+                        </button>
+                    );
+                })}
             </div>
 
-            <div className="mt-0 p-4">
+            <div>
                 {tabs.map((t, i) => (
                     <div
                         key={t.id}

--- a/src/components/__tests__/PublicBets.test.tsx
+++ b/src/components/__tests__/PublicBets.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { BetMarket, BetSource, BetStatus } from '@bryandebaun/mcp-client';
+import PublicBets from '@/components/PublicBets';
+import type {
+    PublicBet,
+    PublicBetAnalytics,
+    PublicBetMetrics,
+} from '@/lib/services/public-bets';
+
+const metrics: PublicBetMetrics = {
+    count: 4,
+    pending: 1,
+    settled: 3,
+    wins: 2,
+    losses: 1,
+    pushes: 0,
+    voids: 0,
+    hitRate: 0.667,
+    roi: 0.12,
+    units: 1.5,
+    clvCount: 3,
+    avgClvPct: 2.1,
+};
+
+const analytics: PublicBetAnalytics = {
+    overall: metrics,
+    bySource: { INTUITION: metrics, AI_ASSISTED: metrics },
+};
+
+const aiBet: PublicBet = {
+    id: 1,
+    placedAt: '2026-06-01T12:00:00.000Z',
+    sport: 'Soccer',
+    league: 'EPL',
+    event: 'Arsenal vs. Chelsea',
+    market: BetMarket.Moneyline,
+    selection: 'Arsenal',
+    line: null,
+    oddsAmerican: -120,
+    status: BetStatus.WON,
+    source: BetSource.AI_ASSISTED,
+    settledAt: '2026-06-02T12:00:00.000Z',
+    closingOddsAmerican: -135,
+    aiModel: 'gpt-x',
+    aiRationale: 'Edge on home form.',
+    aiEstProb: 0.6,
+    aiEV: 0.08,
+    legs: [],
+};
+
+describe('PublicBets', () => {
+    it('renders the scoreboard and a pick with no dollar signs', () => {
+        const { container } = render(
+            <PublicBets bets={[aiBet]} analytics={analytics} />,
+        );
+
+        // Pick is rendered.
+        expect(screen.getByText('Arsenal vs. Chelsea')).toBeInTheDocument();
+        expect(screen.getByText('gpt-x')).toBeInTheDocument();
+        // Scoreboard sources are present.
+        expect(screen.getByText('Intuition')).toBeInTheDocument();
+        expect(screen.getByText('AI-assisted')).toBeInTheDocument();
+
+        // Money must never render: no `$` anywhere in the output.
+        expect(container.textContent ?? '').not.toContain('$');
+    });
+
+    it('shows the empty state when there are no picks', () => {
+        render(<PublicBets bets={[]} analytics={null} />);
+        expect(
+            screen.getByText(/no picks to show just yet/i),
+        ).toBeInTheDocument();
+    });
+});

--- a/src/components/__tests__/Tabs.test.tsx
+++ b/src/components/__tests__/Tabs.test.tsx
@@ -13,24 +13,21 @@ describe('Tabs component', () => {
         const tabA = screen.getByRole('tab', { name: 'A' });
         const tabB = screen.getByRole('tab', { name: 'B' });
 
-        // initial selection
+        // initial selection: A active (open folder tab), B/C inactive
         expect(tabA).toHaveAttribute('aria-selected', 'true');
+        expect(tabB).toHaveAttribute('aria-selected', 'false');
+        // active tab merges into the content box: bordered, no bottom border
         expect(tabA.className).toContain('border-b-0');
-        expect(tabA.className).toContain('rounded-b-none');
-        expect(tabA.className).toContain('shadow-sm');
-        expect(tabA.className).toContain('-mt-1');
-        expect(tabA.className).toContain('first:rounded-bl-none');
-        const tabC = screen.getByRole('tab', { name: 'C' });
-        expect(tabC.className).toContain('last:rounded-br-none');
-        expect(tabB.className).toContain('border');
-        expect(tabB.className).toContain('rounded-b-lg');
-        expect(tabB.className).toContain('shadow-sm');
+        expect(tabA.className).toContain('rounded-t-md');
+        // inactive tabs have no box (transparent border)
+        expect(tabB.className).toContain('border-transparent');
 
         // switch selection
         fireEvent.click(tabB);
         expect(tabB).toHaveAttribute('aria-selected', 'true');
+        expect(tabA).toHaveAttribute('aria-selected', 'false');
         expect(tabB.className).toContain('border-b-0');
-        expect(tabB.className).toContain('rounded-b-lg');
+        expect(tabA.className).toContain('border-transparent');
     });
 
     it('panel container has no border around content', () => {

--- a/src/components/admin/BetForm.tsx
+++ b/src/components/admin/BetForm.tsx
@@ -142,6 +142,8 @@ export default function BetForm({
         const stakeNum = numOrUndefined(stake);
 
         // Parse complete parlay legs (event + selection + valid odds).
+        // Per-leg odds are optional (mcp-server #137) — same-game parlays don't
+        // expose them. A leg just needs event + selection.
         const parsedLegs: BetLeg[] = legs
             .map((l) => ({
                 event: l.event.trim(),
@@ -149,13 +151,13 @@ export default function BetForm({
                 oddsAmerican: numOrUndefined(l.oddsAmerican),
                 line: numOrUndefined(l.line),
             }))
-            .filter(
-                (l) => l.event && l.selection && l.oddsAmerican !== undefined,
-            )
+            .filter((l) => l.event && l.selection)
             .map((l) => ({
                 event: l.event,
                 selection: l.selection,
-                oddsAmerican: l.oddsAmerican as number,
+                ...(l.oddsAmerican !== undefined
+                    ? { oddsAmerican: l.oddsAmerican }
+                    : {}),
                 ...(l.line !== undefined ? { line: l.line } : {}),
             }));
 
@@ -187,7 +189,7 @@ export default function BetForm({
         );
         if (isParlay && hasLegInput && parsedLegs.length < 2) {
             setError(
-                'For parlay legs, complete at least 2 (each needs event, selection, odds) or clear them.',
+                'For parlay legs, complete at least 2 (each needs event + selection; odds optional) or clear them.',
             );
             return;
         }
@@ -499,12 +501,12 @@ export default function BetForm({
                                 Parlay legs
                             </legend>
                             <p className="text-xs text-[var(--color-norwegian-600)] dark:text-[var(--color-norwegian-300)]">
-                                Legs are optional — same-game parlays often
-                                don&apos;t show per-leg odds. If your book lists
-                                each price, add 2+ legs; otherwise just set the
-                                combined odds + total stake above and note the
-                                selections. Per-leg Line is only for
-                                totals/spreads (e.g. Over 2.5 → 2.5).
+                                Add 2+ legs (event + selection required;
+                                per-leg <strong>odds optional</strong> — leave
+                                blank for same-game parlays that don&apos;t show
+                                them). Combined odds + total stake go above.
+                                Per-leg Line is only for totals/spreads (e.g.
+                                Over 2.5 → 2.5).
                             </p>
                             {legs.length === 0 ? (
                                 <p className="text-sm text-[var(--color-norwegian-600)] dark:text-[var(--color-norwegian-300)]">

--- a/src/components/admin/BetForm.tsx
+++ b/src/components/admin/BetForm.tsx
@@ -9,7 +9,13 @@ import {
     BetSource,
 } from '@bryandebaun/mcp-client';
 import Select from '@/components/Select';
-import { BOOK_OPTIONS, MARKET_OPTIONS, SPORT_OPTIONS } from '@/lib/bets';
+import {
+    BOOK_OPTIONS,
+    MARKET_OPTIONS,
+    SPORT_OPTIONS,
+    formatCurrency,
+    potentialReturn,
+} from '@/lib/bets';
 
 /** A parlay leg as edited in the form (string-valued inputs + stable key). */
 interface LegInput {
@@ -105,6 +111,12 @@ export default function BetForm({
         book && !BOOK_OPTIONS.some((o) => o.value === book)
             ? [{ value: book, label: book }, ...BOOK_OPTIONS]
             : BOOK_OPTIONS;
+
+    // Live, derived (never stored) payout — total return if the bet wins.
+    const payout = potentialReturn(
+        numOrUndefined(stake) ?? null,
+        numOrUndefined(oddsAmerican) ?? null,
+    );
 
     const addLeg = () =>
         setLegs((prev) => [
@@ -466,6 +478,20 @@ export default function BetForm({
                             />
                         </div>
                     </div>
+
+                    {payout !== null ? (
+                        <p className="text-sm text-[var(--color-norwegian-700)] dark:text-[var(--color-norwegian-200)]">
+                            {isParlay ? 'Parlay payout' : 'Potential payout'}:{' '}
+                            <strong>{formatCurrency(payout)}</strong>{' '}
+                            <span className="text-[var(--color-norwegian-500)]">
+                                (to win{' '}
+                                {formatCurrency(
+                                    payout - (numOrUndefined(stake) ?? 0),
+                                )}
+                                )
+                            </span>
+                        </p>
+                    ) : null}
 
                     {isParlay ? (
                         <fieldset className="rounded-md border border-[var(--color-norwegian-300)] dark:border-[var(--color-norwegian-600)] p-3 space-y-3">

--- a/src/components/admin/BetForm.tsx
+++ b/src/components/admin/BetForm.tsx
@@ -409,7 +409,11 @@ export default function BetForm({
                         </div>
                     </div>
 
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                    <div
+                        className={`grid grid-cols-1 gap-3 items-end ${
+                            isParlay ? 'sm:grid-cols-2' : 'sm:grid-cols-3'
+                        }`}
+                    >
                         {!isParlay ? (
                             <div>
                                 <label

--- a/src/components/admin/BetsAdmin.tsx
+++ b/src/components/admin/BetsAdmin.tsx
@@ -24,6 +24,7 @@ import {
     formatClvPercent,
     formatCurrency,
     marketLabel,
+    potentialReturn,
 } from '@/lib/bets';
 
 const SETTLE_OPTIONS: SettleBetRequest['status'][] = [
@@ -244,8 +245,23 @@ export default function BetsAdmin(_props: Props) {
             {
                 id: 'payout',
                 header: 'Payout',
-                cell: (info: CellContext<Bet, unknown>) =>
-                    formatCurrency(info.row.original.payout),
+                cell: (info: CellContext<Bet, unknown>) => {
+                    const bet = info.row.original;
+                    // Settled bets show the actual payout; pending bets show the
+                    // estimated return (derived from stake + odds), marked with ~.
+                    if (bet.payout != null) return formatCurrency(bet.payout);
+                    const est = potentialReturn(bet.stake, bet.oddsAmerican);
+                    return est != null ? (
+                        <span
+                            className="italic text-[var(--color-norwegian-500)]"
+                            title="Estimated payout if this bet wins"
+                        >
+                            ~{formatCurrency(est)}
+                        </span>
+                    ) : (
+                        '—'
+                    );
+                },
             },
             {
                 id: 'clv',

--- a/src/components/admin/BetsAdmin.tsx
+++ b/src/components/admin/BetsAdmin.tsx
@@ -189,12 +189,15 @@ export default function BetsAdmin(_props: Props) {
             {
                 id: 'event',
                 header: 'Event',
-                meta: {
-                    headerClassName: 'text-left',
-                    cellClassName: 'text-left whitespace-normal max-w-[14rem]',
+                meta: { headerClassName: 'text-left', cellClassName: 'text-left' },
+                cell: (info: CellContext<Bet, unknown>) => {
+                    const v = info.row.original.event;
+                    return (
+                        <span className="block max-w-[12rem] truncate" title={v}>
+                            {v}
+                        </span>
+                    );
                 },
-                cell: (info: CellContext<Bet, unknown>) =>
-                    info.row.original.event,
             },
             {
                 id: 'market',
@@ -205,15 +208,18 @@ export default function BetsAdmin(_props: Props) {
             {
                 id: 'selection',
                 header: 'Selection',
-                meta: {
-                    headerClassName: 'text-left',
-                    cellClassName: 'text-left whitespace-normal max-w-[12rem]',
-                },
+                meta: { headerClassName: 'text-left', cellClassName: 'text-left' },
                 cell: (info: CellContext<Bet, unknown>) => {
                     const b = info.row.original;
-                    return b.line != null
-                        ? `${b.selection} (${b.line > 0 ? '+' : ''}${b.line})`
-                        : b.selection;
+                    const v =
+                        b.line != null
+                            ? `${b.selection} (${b.line > 0 ? '+' : ''}${b.line})`
+                            : b.selection;
+                    return (
+                        <span className="block max-w-[18rem] truncate" title={v}>
+                            {v}
+                        </span>
+                    );
                 },
             },
             {

--- a/src/lib/__tests__/bets.test.ts
+++ b/src/lib/__tests__/bets.test.ts
@@ -127,15 +127,17 @@ describe('formatRecord', () => {
 });
 
 describe('parseBetLegs', () => {
-    it('narrows valid legs and drops malformed entries', () => {
+    it('narrows legs (odds optional) and drops entries missing event/selection', () => {
         const legs = parseBetLegs([
             { event: 'A', selection: 'X', oddsAmerican: -110, line: 2.5 },
             { event: 'B', selection: 'Y', oddsAmerican: 100 },
-            { event: 'bad', selection: 'no-odds' },
+            // same-game parlay leg with no per-leg odds — kept (#137)
+            { event: 'C', selection: 'no-odds' },
+            { selection: 'missing-event' },
             null,
             'nonsense',
         ]);
-        expect(legs).toHaveLength(2);
+        expect(legs).toHaveLength(3);
         expect(legs[0]).toEqual({
             event: 'A',
             selection: 'X',
@@ -143,6 +145,10 @@ describe('parseBetLegs', () => {
             line: 2.5,
         });
         expect(legs[1].line).toBeUndefined();
+        // odds-less leg is retained with undefined odds rather than dropped
+        expect(legs[2].event).toBe('C');
+        expect(legs[2].selection).toBe('no-odds');
+        expect(legs[2].oddsAmerican).toBeUndefined();
     });
     it('returns an empty array for non-array input', () => {
         expect(parseBetLegs(undefined)).toEqual([]);

--- a/src/lib/bets.ts
+++ b/src/lib/bets.ts
@@ -225,15 +225,19 @@ export function parseBetLegs(legs: unknown): BetLeg[] {
     for (const raw of legs) {
         if (raw === null || typeof raw !== 'object') continue;
         const leg = raw as Record<string, unknown>;
+        // event + selection are required; per-leg odds are optional — same-game
+        // parlays often don't expose individual leg prices (see #137).
         if (
             typeof leg.event === 'string' &&
-            typeof leg.selection === 'string' &&
-            typeof leg.oddsAmerican === 'number'
+            typeof leg.selection === 'string'
         ) {
             result.push({
                 event: leg.event,
                 selection: leg.selection,
-                oddsAmerican: leg.oddsAmerican,
+                oddsAmerican:
+                    typeof leg.oddsAmerican === 'number'
+                        ? leg.oddsAmerican
+                        : undefined,
                 line:
                     typeof leg.line === 'number' ? leg.line : undefined,
             });

--- a/src/lib/bets.ts
+++ b/src/lib/bets.ts
@@ -105,6 +105,29 @@ export function americanToDecimal(
 }
 
 /**
+ * Total payout (stake + profit) if the bet wins, derived from stake + American
+ * odds — e.g. $10 at +180 → $28.00. Returns `null` for invalid input. This is
+ * computed for display, never stored (the DB `payout` is the *actual* settled
+ * amount).
+ */
+export function potentialReturn(
+    stake: number | null | undefined,
+    oddsAmerican: number | null | undefined,
+): number | null {
+    const dec = americanToDecimal(oddsAmerican);
+    if (
+        dec === null ||
+        stake === null ||
+        stake === undefined ||
+        Number.isNaN(stake) ||
+        stake <= 0
+    ) {
+        return null;
+    }
+    return stake * dec;
+}
+
+/**
  * Closing-line value (CLV) as a percentage: how much better/worse the odds you
  * took were versus the closing odds, expressed as the percentage change in
  * decimal payout. Positive means you beat the close (good).

--- a/src/lib/services/__tests__/public-bets.test.ts
+++ b/src/lib/services/__tests__/public-bets.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `public-bets.ts` is `server-only`; that marker package throws under the
+// default (node) condition vitest resolves. Stub it to a no-op so the module
+// can be imported in tests.
+vi.mock('server-only', () => ({}));
+
+const listBets = vi.fn();
+const getAnalytics = vi.fn();
+
+vi.mock('@/lib/mcp', () => ({
+    createApi: () => ({ api: { listBets, getAnalytics } }),
+}));
+
+// Keep the real Bet enums so status/source/market comparisons behave as in prod.
+vi.mock('@bryandebaun/mcp-client', async (importOriginal) => {
+    const actual =
+        await importOriginal<typeof import('@bryandebaun/mcp-client')>();
+    return actual;
+});
+
+import {
+    getPublicBetAnalytics,
+    listPublicBets,
+} from '@/lib/services/public-bets';
+
+/** A raw upstream bet carrying every money field we must strip. */
+const rawBet = {
+    id: 7,
+    placedAt: '2026-06-01T12:00:00.000Z',
+    sport: 'Soccer',
+    league: 'EPL',
+    event: 'Arsenal vs. Chelsea',
+    market: 'moneyline',
+    selection: 'Arsenal',
+    line: null,
+    oddsAmerican: -120,
+    stake: 50, // money — must NOT leak
+    book: 'DraftKings',
+    status: 'WON',
+    settledAt: '2026-06-02T12:00:00.000Z',
+    payout: 91.67, // money — must NOT leak
+    source: 'AI_ASSISTED',
+    aiModel: 'gpt-x',
+    aiRationale: 'Edge on home form.',
+    aiEstProb: 0.6,
+    aiEV: 0.08,
+    closingLine: null,
+    closingOddsAmerican: -135,
+    legs: [
+        {
+            event: 'Arsenal vs. Chelsea',
+            selection: 'Arsenal',
+            oddsAmerican: -120,
+            line: 0,
+        },
+    ],
+    notes: 'private note', // must NOT leak
+    createdAt: '2026-06-01T12:00:00.000Z',
+    updatedAt: '2026-06-02T12:00:00.000Z',
+};
+
+/** A raw metrics block carrying the money fields (`staked`, `profit`). */
+const rawMetrics = {
+    count: 3,
+    pending: 1,
+    settled: 2,
+    wins: 1,
+    losses: 1,
+    pushes: 0,
+    voids: 0,
+    hitRate: 0.5,
+    staked: 150, // money — must NOT leak
+    profit: -10, // money — must NOT leak
+    roi: -0.066,
+    units: -0.2,
+    clvCount: 2,
+    avgClvPct: 1.4,
+};
+
+const rawAnalytics = {
+    overall: rawMetrics,
+    bySource: {
+        INTUITION: rawMetrics,
+        AI_ASSISTED: rawMetrics,
+    },
+};
+
+const MONEY_BET_KEYS = ['stake', 'payout', 'notes', 'book'];
+const MONEY_METRIC_KEYS = ['staked', 'profit'];
+
+beforeEach(() => {
+    listBets.mockReset();
+    getAnalytics.mockReset();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('listPublicBets — money sanitization (security guard)', () => {
+    it('maps to the public allowlist and strips every money field', async () => {
+        listBets.mockResolvedValue({ data: { bets: [rawBet], total: 1 } });
+
+        const result = await listPublicBets();
+        expect(result).toHaveLength(1);
+        const bet = result[0];
+
+        // Allowed fields survive.
+        expect(bet.id).toBe(7);
+        expect(bet.event).toBe('Arsenal vs. Chelsea');
+        expect(bet.oddsAmerican).toBe(-120);
+        expect(bet.closingOddsAmerican).toBe(-135);
+        expect(bet.aiModel).toBe('gpt-x');
+        expect(bet.aiRationale).toBe('Edge on home form.');
+
+        // Money fields are gone — explicit per-key regression assertions.
+        expect(bet).not.toHaveProperty('stake');
+        expect(bet).not.toHaveProperty('payout');
+        expect(bet).not.toHaveProperty('notes');
+        for (const key of MONEY_BET_KEYS) {
+            expect(Object.keys(bet)).not.toContain(key);
+        }
+        // Belt-and-suspenders: no field name even hints at money.
+        for (const key of Object.keys(bet)) {
+            expect(key).not.toMatch(/stake|payout|profit|amount|notes/i);
+        }
+    });
+
+    it('strips money fields from parlay legs too', async () => {
+        listBets.mockResolvedValue({ data: { bets: [rawBet], total: 1 } });
+        const [bet] = await listPublicBets();
+        expect(bet.legs).toHaveLength(1);
+        const leg = bet.legs[0];
+        expect(leg).toEqual({
+            event: 'Arsenal vs. Chelsea',
+            selection: 'Arsenal',
+            oddsAmerican: -120,
+            line: 0,
+        });
+        expect(leg).not.toHaveProperty('stake');
+        expect(leg).not.toHaveProperty('payout');
+    });
+
+    it('returns an empty list when the API throws (graceful failure)', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        listBets.mockRejectedValue(new Error('network down'));
+        await expect(listPublicBets()).resolves.toEqual([]);
+    });
+
+    it('returns an empty list when the payload has no bets', async () => {
+        listBets.mockResolvedValue({ data: {} });
+        await expect(listPublicBets()).resolves.toEqual([]);
+    });
+});
+
+describe('getPublicBetAnalytics — money sanitization (security guard)', () => {
+    it('maps metrics to the allowlist and strips staked/profit', async () => {
+        getAnalytics.mockResolvedValue({ data: rawAnalytics });
+
+        const result = await getPublicBetAnalytics();
+        expect(result).not.toBeNull();
+        const blocks = [
+            result?.overall,
+            result?.bySource.INTUITION,
+            result?.bySource.AI_ASSISTED,
+        ];
+
+        for (const m of blocks) {
+            expect(m).toBeDefined();
+            if (!m) continue;
+            // Allowed dimensionless metrics survive.
+            expect(m.roi).toBe(-0.066);
+            expect(m.units).toBe(-0.2);
+            expect(m.avgClvPct).toBe(1.4);
+            expect(m.hitRate).toBe(0.5);
+
+            // Dollar fields are gone.
+            expect(m).not.toHaveProperty('staked');
+            expect(m).not.toHaveProperty('profit');
+            for (const key of MONEY_METRIC_KEYS) {
+                expect(Object.keys(m)).not.toContain(key);
+            }
+        }
+    });
+
+    it('returns null when the API throws (graceful failure)', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        getAnalytics.mockRejectedValue(new Error('boom'));
+        await expect(getPublicBetAnalytics()).resolves.toBeNull();
+    });
+
+    it('returns null when the payload is malformed', async () => {
+        getAnalytics.mockResolvedValue({ data: {} });
+        await expect(getPublicBetAnalytics()).resolves.toBeNull();
+    });
+});

--- a/src/lib/services/__tests__/public-bets.test.ts
+++ b/src/lib/services/__tests__/public-bets.test.ts
@@ -90,11 +90,17 @@ const MONEY_BET_KEYS = ['stake', 'payout', 'notes', 'book'];
 const MONEY_METRIC_KEYS = ['staked', 'profit'];
 
 beforeEach(() => {
+    // The service short-circuits to empty/null unless the MCP env is present
+    // (`mcpConfigured()`). Stub it so these tests are environment-independent —
+    // CI has no MCP_* vars, which otherwise masks the mocked happy path.
+    vi.stubEnv('MCP_API_KEY', 'test-key');
+    vi.stubEnv('MCP_BASE_URL', 'https://mcp.test');
     listBets.mockReset();
     getAnalytics.mockReset();
 });
 
 afterEach(() => {
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
 });
 

--- a/src/lib/services/public-bets.ts
+++ b/src/lib/services/public-bets.ts
@@ -1,0 +1,199 @@
+import 'server-only';
+
+import type {
+    Bet,
+    BetAnalyticsResponse,
+    BetLeg,
+    BetMarket,
+    BetMetrics,
+    BetSource,
+    BetStatus,
+} from '@bryandebaun/mcp-client';
+import { createApi } from '@/lib/mcp';
+import { unwrapApiResponse } from '@/lib/api-response';
+import { parseBetLegs } from '@/lib/bets';
+
+/**
+ * Public, read-only Bets service.
+ *
+ * Surfaces Bryan's intuition-vs-AI betting experiment on the public `/media`
+ * page. It reads the MCP Bet endpoints with the **server-to-server gateway key**
+ * (`createApi()` with no user token → sends `MCP_API_KEY`, which satisfies the
+ * `@Security('api_key')` read endpoints) and maps every record through a strict
+ * **allowlist** into money-free DTOs.
+ *
+ * SECURITY: this module is `server-only`. The gateway key and the raw money
+ * fields (`stake`, `payout`, `notes`, `staked`, `profit`) must NEVER reach the
+ * client. The mappers below copy field-by-field — they do **not** spread the
+ * raw upstream object — so a new money field added upstream can never leak by
+ * accident. The accompanying test asserts the DTOs do not carry those keys.
+ */
+
+/**
+ * A single pick, with ZERO money fields. Field-by-field allowlist of {@link Bet}.
+ *
+ * Intentionally EXCLUDES `stake`, `payout`, `notes`, `book` and anything
+ * money-derived. (`book` is the sportsbook name — harmless, but the public view
+ * has no use for it and omitting it keeps the surface minimal.)
+ */
+export interface PublicBet {
+    id: number;
+    placedAt: string;
+    sport: string;
+    league: string | null;
+    event: string;
+    market: BetMarket;
+    selection: string;
+    line: number | null;
+    oddsAmerican: number;
+    status: BetStatus;
+    source: BetSource;
+    settledAt: string | null;
+    closingOddsAmerican: number | null;
+    aiModel: string | null;
+    aiRationale: string | null;
+    aiEstProb: number | null;
+    aiEV: number | null;
+    legs: PublicBetLeg[];
+}
+
+/** A parlay leg, money-free (legs never carry money fields). */
+export interface PublicBetLeg {
+    event: string;
+    selection: string;
+    oddsAmerican: number | null;
+    line: number | null;
+}
+
+/**
+ * Money-free metrics. Allowlist of {@link BetMetrics} that EXCLUDES `staked`
+ * and `profit` (both dollars). `roi` (ratio), `units` (unit count) and
+ * `avgClvPct` (%) are dimensionless and safe to expose.
+ */
+export interface PublicBetMetrics {
+    count: number;
+    pending: number;
+    settled: number;
+    wins: number;
+    losses: number;
+    pushes: number;
+    voids: number;
+    hitRate: number | null;
+    roi: number | null;
+    units: number | null;
+    clvCount: number;
+    avgClvPct: number | null;
+}
+
+export interface PublicBetAnalytics {
+    overall: PublicBetMetrics;
+    bySource: {
+        INTUITION: PublicBetMetrics;
+        AI_ASSISTED: PublicBetMetrics;
+    };
+}
+
+/** Map a single upstream {@link Bet} to a money-free {@link PublicBet}. */
+function toPublicBet(bet: Bet): PublicBet {
+    const legs: PublicBetLeg[] = parseBetLegs(bet.legs).map(
+        (leg: BetLeg) => ({
+            event: leg.event,
+            selection: leg.selection,
+            oddsAmerican: leg.oddsAmerican ?? null,
+            line: leg.line ?? null,
+        }),
+    );
+
+    return {
+        id: bet.id,
+        placedAt: bet.placedAt,
+        sport: bet.sport,
+        league: bet.league ?? null,
+        event: bet.event,
+        market: bet.market,
+        selection: bet.selection,
+        line: bet.line ?? null,
+        oddsAmerican: bet.oddsAmerican,
+        status: bet.status,
+        source: bet.source,
+        settledAt: bet.settledAt ?? null,
+        closingOddsAmerican: bet.closingOddsAmerican ?? null,
+        aiModel: bet.aiModel ?? null,
+        aiRationale: bet.aiRationale ?? null,
+        aiEstProb: bet.aiEstProb ?? null,
+        aiEV: bet.aiEV ?? null,
+        legs,
+    };
+}
+
+/** Map upstream {@link BetMetrics} to money-free {@link PublicBetMetrics}. */
+function toPublicMetrics(m: BetMetrics): PublicBetMetrics {
+    return {
+        count: m.count,
+        pending: m.pending,
+        settled: m.settled,
+        wins: m.wins,
+        losses: m.losses,
+        pushes: m.pushes,
+        voids: m.voids,
+        hitRate: m.hitRate,
+        roi: m.roi,
+        units: m.units,
+        clvCount: m.clvCount,
+        avgClvPct: m.avgClvPct,
+    };
+}
+
+function toPublicAnalytics(
+    res: BetAnalyticsResponse,
+): PublicBetAnalytics {
+    return {
+        overall: toPublicMetrics(res.overall),
+        bySource: {
+            INTUITION: toPublicMetrics(res.bySource.INTUITION),
+            AI_ASSISTED: toPublicMetrics(res.bySource.AI_ASSISTED),
+        },
+    };
+}
+
+/** Whether the MCP client is configured at all (env present). */
+function mcpConfigured(): boolean {
+    return Boolean(process.env.MCP_API_KEY || process.env.MCP_BASE_URL);
+}
+
+/**
+ * Fetch all bets and return them as money-free {@link PublicBet}s. Fails
+ * gracefully (empty list) when the API is unreachable or unconfigured, mirroring
+ * the books service, so the public page always renders.
+ */
+export async function listPublicBets(): Promise<PublicBet[]> {
+    if (!mcpConfigured()) return [];
+    try {
+        const api = createApi();
+        const res = await api.api.listBets();
+        const payload = unwrapApiResponse<{ bets?: Bet[] }>(res);
+        const bets = payload?.bets ?? [];
+        return bets.map(toPublicBet);
+    } catch (e) {
+        console.error('listPublicBets failed; returning empty list', e);
+        return [];
+    }
+}
+
+/**
+ * Fetch the intuition-vs-AI scoreboard as money-free analytics. Returns `null`
+ * on failure so the UI can show an empty state.
+ */
+export async function getPublicBetAnalytics(): Promise<PublicBetAnalytics | null> {
+    if (!mcpConfigured()) return null;
+    try {
+        const api = createApi();
+        const res = await api.api.getAnalytics();
+        const payload = unwrapApiResponse<BetAnalyticsResponse>(res);
+        if (!payload?.overall || !payload?.bySource) return null;
+        return toPublicAnalytics(payload);
+    } catch (e) {
+        console.error('getPublicBetAnalytics failed; returning null', e);
+        return null;
+    }
+}


### PR DESCRIPTION
﻿## Summary

Two related bet-form improvements (follow-ups to #100/#105):

**1. Derived potential payout** (never stored — computed from `stake` × odds):
- `potentialReturn()` helper in `src/lib/bets.ts` (e.g. $10 @ +180 → $28.00).
- Bet form shows a live "Potential payout: $X (to win $Y)" line as you type (combined odds for parlays).
- Bet log shows the **estimated** return for pending bets (`~$28`), the **actual** payout once settled.

**2. Odds-less parlay legs (mcp-server #137 frontend):**
- The backend now makes per-leg `oddsAmerican` optional, so the legs editor accepts legs with just **event + selection** — same-game parlays (which don't expose per-leg odds) can finally be captured structurally.
- Regenerated `@bryandebaun/mcp-client` to pick up the optional `BetLeg.oddsAmerican` (also fixes the `verify-mcp-client` drift).

## Verification
- `pnpm run lint` clean · `pnpm test` 268 pass · `pnpm run build` OK · `build:packages` OK.
