### PR TITLE
feat: theme-aware SVG diagrams in articles (light/dark auto-swap)

### DIFF
--- a/public/articles/xe_all_committed.svg
+++ b/public/articles/xe_all_committed.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="300" viewBox="0 0 700 300" role="img" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <title>All eleven players committed</title>
+  <desc>Eleven effort bars all sitting above the expected bar. The straight average and the weakest-link mean land in nearly the same place, both above the bar.</desc>
+  <text x="120" y="30" font-size="15" font-weight="500" fill="#2C2C2A">All eleven committed</text>
+
+  <line x1="120" y1="93.9" x2="500" y2="93.9" stroke="#B4B2A9" stroke-width="1" stroke-dasharray="2 4"/>
+  <text x="112" y="97" font-size="12" fill="#5F5E5A" text-anchor="end">Expected bar (1.0)</text>
+
+  <rect x="120.0" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="155.1" y="86.5" width="29.1" height="153.5" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="190.2" y="76.3" width="29.1" height="163.7" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="225.3" y="82.2" width="29.1" height="157.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="260.4" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="295.5" y="73.4" width="29.1" height="166.6" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="330.5" y="85.1" width="29.1" height="154.9" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="365.6" y="77.8" width="29.1" height="162.2" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="400.7" y="80.7" width="29.1" height="159.3" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="435.8" y="74.9" width="29.1" height="165.1" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="470.9" y="83.6" width="29.1" height="156.4" rx="3" fill="#1D9E75" opacity="0.85"/>
+
+  <line x1="120" y1="240" x2="500" y2="240" stroke="#888780" stroke-width="1"/>
+
+  <line x1="120" y1="79.9" x2="500" y2="79.9" stroke="#888780" stroke-width="2" stroke-dasharray="6 4"/>
+  <line x1="120" y1="80.0" x2="500" y2="80.0" stroke="#534AB7" stroke-width="2"/>
+
+  <line x1="500" y1="80" x2="512" y2="68" stroke="#B4B2A9" stroke-width="0.75"/>
+  <text x="516" y="66" font-size="12" fill="#5F5E5A">Average 1.10</text>
+  <text x="516" y="82" font-size="12" fill="#534AB7">Weakest-link 1.09</text>
+  <text x="516" y="98" font-size="12" fill="#888780">they agree</text>
+
+  <text x="120" y="278" font-size="12" fill="#5F5E5A">When everyone meets the bar, the two ways of scoring the team land in the same place.</text>
+</svg>

--- a/public/articles/xe_all_committed_dark.svg
+++ b/public/articles/xe_all_committed_dark.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="300" viewBox="0 0 700 300" role="img" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <title>All eleven players committed (dark)</title>
+  <desc>Eleven effort bars all sitting above the expected bar. The straight average and the weakest-link mean land in nearly the same place, both above the bar.</desc>
+  <text x="120" y="30" font-size="15" font-weight="500" fill="#E8E6DD">All eleven committed</text>
+
+  <line x1="120" y1="93.9" x2="500" y2="93.9" stroke="#73726C" stroke-width="1" stroke-dasharray="2 4"/>
+  <text x="112" y="97" font-size="12" fill="#9C9A92" text-anchor="end">Expected bar (1.0)</text>
+
+  <rect x="120.0" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="155.1" y="86.5" width="29.1" height="153.5" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="190.2" y="76.3" width="29.1" height="163.7" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="225.3" y="82.2" width="29.1" height="157.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="260.4" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="295.5" y="73.4" width="29.1" height="166.6" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="330.5" y="85.1" width="29.1" height="154.9" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="365.6" y="77.8" width="29.1" height="162.2" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="400.7" y="80.7" width="29.1" height="159.3" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="435.8" y="74.9" width="29.1" height="165.1" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="470.9" y="83.6" width="29.1" height="156.4" rx="3" fill="#1D9E75" opacity="0.9"/>
+
+  <line x1="120" y1="240" x2="500" y2="240" stroke="#888780" stroke-width="1"/>
+
+  <line x1="120" y1="79.9" x2="500" y2="79.9" stroke="#B4B2A9" stroke-width="2" stroke-dasharray="6 4"/>
+  <line x1="120" y1="80.0" x2="500" y2="80.0" stroke="#AFA9EC" stroke-width="2"/>
+
+  <line x1="500" y1="80" x2="512" y2="68" stroke="#73726C" stroke-width="0.75"/>
+  <text x="516" y="66" font-size="12" fill="#C2C0B6">Average 1.10</text>
+  <text x="516" y="82" font-size="12" fill="#AFA9EC">Weakest-link 1.09</text>
+  <text x="516" y="98" font-size="12" fill="#888780">they agree</text>
+
+  <text x="120" y="278" font-size="12" fill="#9C9A92">When everyone meets the bar, the two ways of scoring the team land in the same place.</text>
+</svg>

--- a/public/articles/xe_one_quits.svg
+++ b/public/articles/xe_one_quits.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="300" viewBox="0 0 700 300" role="img" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <title>One player checks out</title>
+  <desc>Ten effort bars stay above the expected bar while one collapses near zero. The straight average barely moves and stays just above the bar, but the weakest-link mean drops well below it.</desc>
+  <text x="120" y="30" font-size="15" font-weight="500" fill="#2C2C2A">One player checks out</text>
+
+  <line x1="120" y1="93.9" x2="500" y2="93.9" stroke="#B4B2A9" stroke-width="1" stroke-dasharray="2 4"/>
+  <text x="112" y="97" font-size="12" fill="#5F5E5A" text-anchor="end">Expected bar (1.0)</text>
+
+  <rect x="120.0" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="155.1" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="190.2" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="225.3" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="260.4" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="295.5" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="330.5" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="365.6" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="400.7" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="435.8" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="470.9" y="218.1" width="29.1" height="21.9" rx="3" fill="#D85A30" opacity="0.9"/>
+
+  <line x1="120" y1="240" x2="500" y2="240" stroke="#888780" stroke-width="1"/>
+
+  <line x1="120" y1="91.9" x2="500" y2="91.9" stroke="#888780" stroke-width="2" stroke-dasharray="6 4"/>
+  <line x1="120" y1="138.0" x2="500" y2="138.0" stroke="#534AB7" stroke-width="2"/>
+
+  <text x="516" y="88" font-size="12" fill="#5F5E5A">Average 1.01</text>
+  <text x="516" y="142" font-size="12" fill="#534AB7">Weakest-link 0.70</text>
+  <line x1="485" y1="218" x2="478" y2="200" stroke="#B4B2A9" stroke-width="0.75"/>
+  <text x="470" y="196" font-size="12" fill="#993C1D" text-anchor="middle">quit</text>
+
+  <text x="120" y="278" font-size="12" fill="#5F5E5A">One player quits. The average barely moves. The weakest-link mean falls below the bar.</text>
+</svg>

--- a/public/articles/xe_one_quits_dark.svg
+++ b/public/articles/xe_one_quits_dark.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="300" viewBox="0 0 700 300" role="img" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <title>One player checks out (dark)</title>
+  <desc>Ten effort bars stay above the expected bar while one collapses near zero. The straight average barely moves and stays just above the bar, but the weakest-link mean drops well below it.</desc>
+  <text x="120" y="30" font-size="15" font-weight="500" fill="#E8E6DD">One player checks out</text>
+
+  <line x1="120" y1="93.9" x2="500" y2="93.9" stroke="#73726C" stroke-width="1" stroke-dasharray="2 4"/>
+  <text x="112" y="97" font-size="12" fill="#9C9A92" text-anchor="end">Expected bar (1.0)</text>
+
+  <rect x="120.0" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="155.1" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="190.2" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="225.3" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="260.4" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="295.5" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="330.5" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="365.6" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="400.7" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="435.8" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="470.9" y="218.1" width="29.1" height="21.9" rx="3" fill="#E0784A" opacity="0.95"/>
+
+  <line x1="120" y1="240" x2="500" y2="240" stroke="#888780" stroke-width="1"/>
+
+  <line x1="120" y1="91.9" x2="500" y2="91.9" stroke="#B4B2A9" stroke-width="2" stroke-dasharray="6 4"/>
+  <line x1="120" y1="138.0" x2="500" y2="138.0" stroke="#AFA9EC" stroke-width="2"/>
+
+  <text x="516" y="88" font-size="12" fill="#C2C0B6">Average 1.01</text>
+  <text x="516" y="142" font-size="12" fill="#AFA9EC">Weakest-link 0.70</text>
+  <line x1="485" y1="218" x2="478" y2="200" stroke="#73726C" stroke-width="0.75"/>
+  <text x="470" y="196" font-size="12" fill="#F0997B" text-anchor="middle">quit</text>
+
+  <text x="120" y="278" font-size="12" fill="#9C9A92">One player quits. The average barely moves. The weakest-link mean falls below the bar.</text>
+</svg>

--- a/public/articles/xe_over_expected.svg
+++ b/public/articles/xe_over_expected.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="300" viewBox="0 0 700 300" role="img" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <title>What xE measures: actual effort against the moving bar</title>
+  <desc>Across a match, the expected-effort line bends with the game state while the actual-effort line runs above it early, then drops below it once the team is in control. The gap above the bar is shaded teal as over-expected, the gap below is shaded coral as the deficit xE flags.</desc>
+  <text x="60" y="30" font-size="15" font-weight="500" fill="#2C2C2A">What xE measures: the gap to the bar</text>
+
+  <polygon points="60,77.4 143.3,74.2 226.7,83.8 310,87.0 330.8,97 310,95.0 226.7,98.2 143.3,96.6 60,99.8" fill="#1D9E75" opacity="0.22"/>
+  <polygon points="330.8,97 393.3,103.0 476.7,99.8 560,109.4 560,119.0 476.7,147.8 393.3,127.0 330.8,97" fill="#D85A30" opacity="0.22"/>
+
+  <polyline points="60,99.8 143.3,96.6 226.7,98.2 310,95.0 393.3,103.0 476.7,99.8 560,109.4" fill="none" stroke="#888780" stroke-width="2" stroke-dasharray="6 4"/>
+  <polyline points="60,77.4 143.3,74.2 226.7,83.8 310,87.0 393.3,127.0 476.7,147.8 560,119.0" fill="none" stroke="#2C2C2A" stroke-width="2.5"/>
+
+  <line x1="60" y1="215" x2="560" y2="215" stroke="#888780" stroke-width="1"/>
+  <text x="60" y="232" font-size="12" fill="#5F5E5A" text-anchor="middle">0'</text>
+  <text x="310" y="232" font-size="12" fill="#5F5E5A" text-anchor="middle">45'</text>
+  <text x="560" y="232" font-size="12" fill="#5F5E5A" text-anchor="middle">90'</text>
+  <text x="52" y="60" font-size="12" fill="#888780" text-anchor="end">high</text>
+  <text x="52" y="212" font-size="12" fill="#888780" text-anchor="end">low</text>
+
+  <text x="150" y="66" font-size="12" fill="#0F6E56" text-anchor="middle">over the bar</text>
+  <text x="455" y="116" font-size="12" fill="#993C1D" text-anchor="middle">under the bar</text>
+  <text x="455" y="130" font-size="12" fill="#993C1D" text-anchor="middle">(the deficit xE flags)</text>
+
+  <line x1="60" y1="251" x2="84" y2="251" stroke="#888780" stroke-width="2" stroke-dasharray="6 4"/>
+  <text x="90" y="255" font-size="12" fill="#5F5E5A">Expected effort</text>
+  <line x1="210" y1="251" x2="234" y2="251" stroke="#2C2C2A" stroke-width="2.5"/>
+  <text x="240" y="255" font-size="12" fill="#5F5E5A">Actual effort</text>
+
+  <text x="60" y="280" font-size="12" fill="#5F5E5A">The bar moves with the game. xE is the gap between effort given and effort the moment asked for.</text>
+</svg>

--- a/public/articles/xe_over_expected_dark.svg
+++ b/public/articles/xe_over_expected_dark.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="300" viewBox="0 0 700 300" role="img" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <title>What xE measures: actual effort against the moving bar (dark)</title>
+  <desc>Across a match, the expected-effort line bends with the game state while the actual-effort line runs above it early, then drops below it once the team is in control. The gap above the bar is shaded teal as over-expected, the gap below is shaded coral as the deficit xE flags.</desc>
+  <text x="60" y="30" font-size="15" font-weight="500" fill="#E8E6DD">What xE measures: the gap to the bar</text>
+
+  <polygon points="60,77.4 143.3,74.2 226.7,83.8 310,87.0 330.8,97 310,95.0 226.7,98.2 143.3,96.6 60,99.8" fill="#1D9E75" opacity="0.30"/>
+  <polygon points="330.8,97 393.3,103.0 476.7,99.8 560,109.4 560,119.0 476.7,147.8 393.3,127.0 330.8,97" fill="#E0784A" opacity="0.30"/>
+
+  <polyline points="60,99.8 143.3,96.6 226.7,98.2 310,95.0 393.3,103.0 476.7,99.8 560,109.4" fill="none" stroke="#B4B2A9" stroke-width="2" stroke-dasharray="6 4"/>
+  <polyline points="60,77.4 143.3,74.2 226.7,83.8 310,87.0 393.3,127.0 476.7,147.8 560,119.0" fill="none" stroke="#E8E6DD" stroke-width="2.5"/>
+
+  <line x1="60" y1="215" x2="560" y2="215" stroke="#888780" stroke-width="1"/>
+  <text x="60" y="232" font-size="12" fill="#9C9A92" text-anchor="middle">0'</text>
+  <text x="310" y="232" font-size="12" fill="#9C9A92" text-anchor="middle">45'</text>
+  <text x="560" y="232" font-size="12" fill="#9C9A92" text-anchor="middle">90'</text>
+  <text x="52" y="60" font-size="12" fill="#888780" text-anchor="end">high</text>
+  <text x="52" y="212" font-size="12" fill="#888780" text-anchor="end">low</text>
+
+  <text x="150" y="66" font-size="12" fill="#5DCAA5" text-anchor="middle">over the bar</text>
+  <text x="455" y="116" font-size="12" fill="#F0997B" text-anchor="middle">under the bar</text>
+  <text x="455" y="130" font-size="12" fill="#F0997B" text-anchor="middle">(the deficit xE flags)</text>
+
+  <line x1="60" y1="251" x2="84" y2="251" stroke="#B4B2A9" stroke-width="2" stroke-dasharray="6 4"/>
+  <text x="90" y="255" font-size="12" fill="#9C9A92">Expected effort</text>
+  <line x1="210" y1="251" x2="234" y2="251" stroke="#E8E6DD" stroke-width="2.5"/>
+  <text x="240" y="255" font-size="12" fill="#9C9A92">Actual effort</text>
+
+  <text x="60" y="280" font-size="12" fill="#9C9A92">The bar moves with the game. xE is the gap between effort given and effort the moment asked for.</text>
+</svg>

--- a/public/articles/xe_two_quit.svg
+++ b/public/articles/xe_two_quit.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="300" viewBox="0 0 700 300" role="img" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <title>Two players check out</title>
+  <desc>Nine effort bars stay above the expected bar while two collapse near zero. The straight average now dips just below the bar, and the weakest-link mean falls far further still.</desc>
+  <text x="120" y="30" font-size="15" font-weight="500" fill="#2C2C2A">Two players check out</text>
+
+  <line x1="120" y1="93.9" x2="500" y2="93.9" stroke="#B4B2A9" stroke-width="1" stroke-dasharray="2 4"/>
+  <text x="112" y="97" font-size="12" fill="#5F5E5A" text-anchor="end">Expected bar (1.0)</text>
+
+  <rect x="120.0" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="155.1" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="190.2" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="225.3" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="260.4" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="295.5" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="330.5" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="365.6" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="400.7" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.85"/>
+  <rect x="435.8" y="218.1" width="29.1" height="21.9" rx="3" fill="#D85A30" opacity="0.9"/>
+  <rect x="470.9" y="218.1" width="29.1" height="21.9" rx="3" fill="#D85A30" opacity="0.9"/>
+
+  <line x1="120" y1="240" x2="500" y2="240" stroke="#888780" stroke-width="1"/>
+
+  <line x1="120" y1="104.5" x2="500" y2="104.5" stroke="#888780" stroke-width="2" stroke-dasharray="6 4"/>
+  <line x1="120" y1="165.3" x2="500" y2="165.3" stroke="#534AB7" stroke-width="2"/>
+
+  <text x="516" y="102" font-size="12" fill="#5F5E5A">Average 0.93</text>
+  <text x="516" y="169" font-size="12" fill="#534AB7">Weakest-link 0.51</text>
+  <text x="467" y="205" font-size="12" fill="#993C1D" text-anchor="middle">two quit</text>
+
+  <text x="120" y="278" font-size="12" fill="#5F5E5A">A second player goes. The average finally dips under the bar; the weakest-link mean craters.</text>
+</svg>

--- a/public/articles/xe_two_quit_dark.svg
+++ b/public/articles/xe_two_quit_dark.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="300" viewBox="0 0 700 300" role="img" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <title>Two players check out (dark)</title>
+  <desc>Nine effort bars stay above the expected bar while two collapse near zero. The straight average now dips just below the bar, and the weakest-link mean falls far further still.</desc>
+  <text x="120" y="30" font-size="15" font-weight="500" fill="#E8E6DD">Two players check out</text>
+
+  <line x1="120" y1="93.9" x2="500" y2="93.9" stroke="#73726C" stroke-width="1" stroke-dasharray="2 4"/>
+  <text x="112" y="97" font-size="12" fill="#9C9A92" text-anchor="end">Expected bar (1.0)</text>
+
+  <rect x="120.0" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="155.1" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="190.2" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="225.3" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="260.4" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="295.5" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="330.5" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="365.6" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="400.7" y="79.2" width="29.1" height="160.8" rx="3" fill="#1D9E75" opacity="0.9"/>
+  <rect x="435.8" y="218.1" width="29.1" height="21.9" rx="3" fill="#E0784A" opacity="0.95"/>
+  <rect x="470.9" y="218.1" width="29.1" height="21.9" rx="3" fill="#E0784A" opacity="0.95"/>
+
+  <line x1="120" y1="240" x2="500" y2="240" stroke="#888780" stroke-width="1"/>
+
+  <line x1="120" y1="104.5" x2="500" y2="104.5" stroke="#B4B2A9" stroke-width="2" stroke-dasharray="6 4"/>
+  <line x1="120" y1="165.3" x2="500" y2="165.3" stroke="#AFA9EC" stroke-width="2"/>
+
+  <text x="516" y="102" font-size="12" fill="#C2C0B6">Average 0.93</text>
+  <text x="516" y="169" font-size="12" fill="#AFA9EC">Weakest-link 0.51</text>
+  <text x="467" y="205" font-size="12" fill="#F0997B" text-anchor="middle">two quit</text>
+
+  <text x="120" y="278" font-size="12" fill="#9C9A92">A second player goes. The average finally dips under the bar; the weakest-link mean craters.</text>
+</svg>

--- a/src/components/ArticleBody.tsx
+++ b/src/components/ArticleBody.tsx
@@ -59,6 +59,59 @@ function MarkdownAnchor({
 }
 
 /**
+ * A themed article SVG is one served from `/articles/…*.svg` that ships with a
+ * matching `…_dark.svg` sibling. We pair them automatically (no authoring
+ * marker) and CSS-swap by theme, so an `<img>` — which can't inherit
+ * `currentColor` — still tracks the site's manual light/dark toggle.
+ */
+function isThemedArticleSvg(src: string): boolean {
+    return /^\/articles\/.+\.svg$/iu.test(src) && !/_dark\.svg$/iu.test(src);
+}
+
+function MarkdownImage({
+    src,
+    alt,
+    title,
+    ...rest
+}: ComponentPropsWithoutRef<'img'>) {
+    if (typeof src === 'string' && isThemedArticleSvg(src)) {
+        const darkSrc = src.replace(/\.svg$/iu, '_dark.svg');
+        // Both variants carry the SAME alt; `display:none` removes the hidden
+        // one from the a11y tree, so exactly one alt is announced per theme.
+        return (
+            <>
+                {/* eslint-disable-next-line @next/next/no-img-element -- DB-authored content path; next/image needs known dimensions/loader we don't have here */}
+                <img
+                    src={src}
+                    alt={alt ?? ''}
+                    title={title}
+                    className="mx-auto block h-auto max-w-full dark:hidden"
+                    {...rest}
+                />
+                {/* eslint-disable-next-line @next/next/no-img-element -- see above */}
+                <img
+                    src={darkSrc}
+                    alt={alt ?? ''}
+                    title={title}
+                    className="mx-auto hidden h-auto max-w-full dark:block"
+                    {...rest}
+                />
+            </>
+        );
+    }
+    return (
+        // eslint-disable-next-line @next/next/no-img-element -- see above
+        <img
+            src={src}
+            alt={alt ?? ''}
+            title={title}
+            className="mx-auto h-auto max-w-full"
+            {...rest}
+        />
+    );
+}
+
+/**
  * Render a DB-sourced Markdown article body as React.
  *
  * Security: bodies come from the database, so we render via `react-markdown`
@@ -73,7 +126,7 @@ export default function ArticleBody({ body }: { body: string }) {
             <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
                 rehypePlugins={[rehypeSanitize]}
-                components={{ a: MarkdownAnchor }}
+                components={{ a: MarkdownAnchor, img: MarkdownImage }}
             >
                 {content}
             </ReactMarkdown>

--- a/src/components/__tests__/ArticleBody.test.tsx
+++ b/src/components/__tests__/ArticleBody.test.tsx
@@ -73,4 +73,44 @@ describe('ArticleBody rendering', () => {
         render(<ArticleBody body={'| a | b |\n| - | - |\n| 1 | 2 |'} />);
         expect(screen.getByRole('table')).toBeInTheDocument();
     });
+
+    it('pairs a themed /articles SVG with its _dark sibling and CSS-swaps', () => {
+        const { container } = render(
+            <ArticleBody body={'![All committed](/articles/xe_all_committed.svg)'} />,
+        );
+        const imgs = Array.from(container.querySelectorAll('img'));
+        expect(imgs).toHaveLength(2);
+
+        const light = imgs[0];
+        const dark = imgs[1];
+        // Light variant: real alt, shown in light mode / hidden in dark.
+        expect(light).toHaveAttribute('src', '/articles/xe_all_committed.svg');
+        expect(light).toHaveAttribute('alt', 'All committed');
+        expect(light.className).toContain('dark:hidden');
+        // Dark variant: derived _dark src, same alt (display:none de-dupes the
+        // a11y tree, so the alt is announced in dark mode too).
+        expect(dark).toHaveAttribute(
+            'src',
+            '/articles/xe_all_committed_dark.svg',
+        );
+        expect(dark).toHaveAttribute('alt', 'All committed');
+        expect(dark.className).toContain('dark:block');
+    });
+
+    it('does not pair non-/articles images (single img, no _dark swap)', () => {
+        const { container } = render(
+            <ArticleBody body={'![logo](/images/logo.svg)'} />,
+        );
+        const imgs = Array.from(container.querySelectorAll('img'));
+        expect(imgs).toHaveLength(1);
+        expect(imgs[0]).toHaveAttribute('src', '/images/logo.svg');
+    });
+
+    it('does not double-pair an already-_dark src', () => {
+        const { container } = render(
+            <ArticleBody body={'![x](/articles/xe_all_committed_dark.svg)'} />,
+        );
+        // Already the dark file → treat as a plain single image.
+        expect(container.querySelectorAll('img')).toHaveLength(1);
+    });
 });


### PR DESCRIPTION
## What

Theme-aware SVG diagrams in articles. Any Markdown image referencing `/articles/*.svg` automatically pairs with its `_dark.svg` sibling and CSS-swaps based on the active theme. Ships the first **4 diagram pairs** under `public/articles/`.

## Why

An SVG embedded via `<img>` can't inherit `currentColor`, so a single file can't follow the site's **manual** light/dark toggle (a `prefers-color-scheme` `<picture>` would only track the OS, not the toggle). Shipping both variants and swapping with `dark:hidden` / `dark:block` makes diagrams track the actual theme.

## Authoring

One normal Markdown image line, referencing the **light** file — the dark swap is automatic:

```markdown
![All eleven committed](/articles/xe_all_committed.svg)
```

Images **not** under `/articles/` render as a single `<img>` (unchanged), so full-color graphics elsewhere are unaffected.

## Accessibility

Both variants carry the **same** `alt`; `display:none` removes the hidden one from the a11y tree, so the description is announced exactly once per theme (including in dark mode).

## Tests

`ArticleBody`: pairing + derived `_dark` src + swap classes; single `<img>` for non-`/articles/` images; no double-pairing of an already-`_dark` src. Full suite green.

## Server / infra

**None.** Pure frontend + static assets. The article body already stores Markdown; this only changes how `/articles/*.svg` images render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
