### PR TITLE
feat: admin image upload to Supabase Storage for articles

### DIFF
--- a/src/app/api/admin/upload/__tests__/route.test.ts
+++ b/src/app/api/admin/upload/__tests__/route.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+vi.mock('@/lib/auth-guard', () => ({
+    requireAdmin: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/lib/supabase/admin', () => ({
+    getAdminSupabase: vi.fn(),
+}));
+
+import { requireAdmin } from '@/lib/auth-guard';
+import { getAdminSupabase } from '@/lib/supabase/admin';
+
+const requireAdminMock = requireAdmin as ReturnType<typeof vi.fn>;
+const getAdminSupabaseMock = getAdminSupabase as ReturnType<typeof vi.fn>;
+
+const forbidden = new Response(JSON.stringify({ error: 'Forbidden' }), {
+    status: 403,
+});
+
+/** Build a mocked service-role storage client and expose its spies. */
+function mockStorage(
+    uploadResult: { error: { message: string } | null } = { error: null },
+) {
+    const upload = vi.fn().mockResolvedValue(uploadResult);
+    const getPublicUrl = vi.fn().mockReturnValue({
+        data: { publicUrl: 'https://storage.example.com/article-assets/key' },
+    });
+    const from = vi.fn().mockReturnValue({ upload, getPublicUrl });
+    getAdminSupabaseMock.mockReturnValue({
+        ok: true,
+        client: { storage: { from } },
+    });
+    return { upload, getPublicUrl, from };
+}
+
+/** Build a NextRequest whose formData() yields the given file (or nothing). */
+function reqWithFile(file: File | null) {
+    const formData = new FormData();
+    if (file) formData.set('file', file);
+    return {
+        formData: vi.fn().mockResolvedValue(formData),
+    } as unknown as NextRequest;
+}
+
+describe('POST /api/admin/upload', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        requireAdminMock.mockResolvedValue(null);
+    });
+
+    it('returns the guard response and never touches storage when not admin', async () => {
+        requireAdminMock.mockResolvedValueOnce(forbidden);
+        const { POST } = await import('../route');
+        const res = await POST(reqWithFile(null));
+        expect((res as Response).status).toBe(403);
+        // Storage client must not even be requested.
+        expect(getAdminSupabaseMock).not.toHaveBeenCalled();
+    });
+
+    it('returns 503 when the service-role client is unconfigured', async () => {
+        getAdminSupabaseMock.mockReturnValue({
+            ok: false,
+            reason: 'unconfigured',
+        });
+        const { POST } = await import('../route');
+        const file = new File(['x'], 'a.png', { type: 'image/png' });
+        const res = await POST(reqWithFile(file));
+        expect((res as Response).status).toBe(503);
+    });
+
+    it('returns 400 when no file is provided', async () => {
+        mockStorage();
+        const { POST } = await import('../route');
+        const res = await POST(reqWithFile(null));
+        expect((res as Response).status).toBe(400);
+    });
+
+    it('returns 400 for a disallowed MIME type', async () => {
+        const { upload } = mockStorage();
+        const { POST } = await import('../route');
+        const file = new File(['x'], 'evil.exe', {
+            type: 'application/octet-stream',
+        });
+        const res = await POST(reqWithFile(file));
+        expect((res as Response).status).toBe(400);
+        expect(upload).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the file exceeds 5 MB', async () => {
+        const { upload } = mockStorage();
+        const { POST } = await import('../route');
+        const big = new File([new Uint8Array(5 * 1024 * 1024 + 1)], 'big.png', {
+            type: 'image/png',
+        });
+        const res = await POST(reqWithFile(big));
+        expect((res as Response).status).toBe(400);
+        expect(upload).not.toHaveBeenCalled();
+    });
+
+    it('uploads with a server-derived key and returns 200 with the url', async () => {
+        const { upload, from } = mockStorage();
+        const { POST } = await import('../route');
+        const file = new File(['x'], '../../etc/passwd.jpeg', {
+            type: 'image/jpeg',
+        });
+        const res = await POST(reqWithFile(file));
+        expect((res as Response).status).toBe(200);
+        const json = await (res as Response).json();
+        expect(json.url).toBe('https://storage.example.com/article-assets/key');
+
+        expect(from).toHaveBeenCalledWith('article-assets');
+        expect(upload).toHaveBeenCalledTimes(1);
+        const key = upload.mock.calls[0][0] as string;
+        // Extension comes from the validated MIME (jpeg -> jpg), not the name.
+        expect(key).toMatch(/^\d{4}\/[0-9a-f-]{36}\.jpg$/);
+        // The key must never carry the original filename or traversal.
+        expect(key).not.toContain('passwd');
+        expect(key).not.toContain('..');
+        expect(key.startsWith('/')).toBe(false);
+        // upsert disabled so an existing object is never overwritten.
+        expect(upload.mock.calls[0][2]).toMatchObject({ upsert: false });
+    });
+
+    it('returns 502 with a clear message when the bucket is missing', async () => {
+        mockStorage({ error: { message: 'Bucket not found' } });
+        const { POST } = await import('../route');
+        const file = new File(['x'], 'a.png', { type: 'image/png' });
+        const res = await POST(reqWithFile(file));
+        expect((res as Response).status).toBe(502);
+        const json = await (res as Response).json();
+        expect(json.error).toMatch(/article-assets/);
+    });
+});

--- a/src/app/api/admin/upload/route.ts
+++ b/src/app/api/admin/upload/route.ts
@@ -1,0 +1,129 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { requireAdmin } from '@/lib/auth-guard';
+import { getAdminSupabase } from '@/lib/supabase/admin';
+
+/**
+ * POST /api/admin/upload
+ *
+ * Uploads an image to the public Supabase Storage bucket `article-assets` and
+ * returns its public URL for embedding in a Markdown article body.
+ *
+ * Authorization: gated by {@link requireAdmin} BEFORE any storage access, so a
+ * non-admin can never reach the service-role client. The service-role client
+ * bypasses RLS (`getAdminSupabase`), which is why admin-only gating is critical.
+ *
+ * SVG note: uploads are admin-only (trusted authors). SVGs are served from the
+ * Supabase Storage origin — a SEPARATE domain from the app — and embedded via
+ * Markdown `<img>` (script-sandboxed, no inline-script execution against our
+ * origin), so we accept them without server-side SVG sanitization. Raster
+ * formats are the common case.
+ */
+
+/** Bucket that must exist (public) in Supabase Storage. */
+const BUCKET = 'article-assets';
+
+/** Max upload size: 5 MB. */
+const MAX_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Allowlist of accepted MIME types mapped to the file extension we control.
+ *
+ * The extension is derived from the VALIDATED MIME type, never from the
+ * user-supplied filename. This prevents extension spoofing and path traversal:
+ * the object key only ever contains a server-generated UUID plus a known-safe
+ * extension from this map.
+ */
+const MIME_TO_EXT: Record<string, string> = {
+    'image/png': 'png',
+    'image/jpeg': 'jpg',
+    'image/webp': 'webp',
+    'image/gif': 'gif',
+    'image/avif': 'avif',
+    'image/svg+xml': 'svg',
+};
+
+export async function POST(request: NextRequest) {
+    // Authorize FIRST — before touching the service-role storage client.
+    const guard = await requireAdmin();
+    if (guard) return guard;
+
+    const admin = getAdminSupabase();
+    if (!admin.ok) {
+        return NextResponse.json(
+            { error: 'Image upload is not configured.' },
+            { status: 503 },
+        );
+    }
+
+    let formData: FormData;
+    try {
+        formData = await request.formData();
+    } catch {
+        return NextResponse.json(
+            { error: 'Expected multipart/form-data with a "file" field.' },
+            { status: 400 },
+        );
+    }
+
+    const fileEntry = formData.get('file');
+    if (!fileEntry || typeof fileEntry === 'string') {
+        return NextResponse.json(
+            { error: 'No file was provided.' },
+            { status: 400 },
+        );
+    }
+
+    const file: File = fileEntry;
+
+    const ext = MIME_TO_EXT[file.type];
+    if (!ext) {
+        return NextResponse.json(
+            {
+                error: `Unsupported image type. Allowed: ${Object.keys(
+                    MIME_TO_EXT,
+                ).join(', ')}.`,
+            },
+            { status: 400 },
+        );
+    }
+
+    if (file.size > MAX_BYTES) {
+        return NextResponse.json(
+            { error: 'Image is too large (max 5 MB).' },
+            { status: 400 },
+        );
+    }
+
+    // Object key is fully server-controlled: a year prefix plus a random UUID
+    // and the validated extension. It never contains the raw filename, "..",
+    // or a leading slash, so traversal and overwrite are impossible.
+    const key = `${new Date().getUTCFullYear()}/${crypto.randomUUID()}.${ext}`;
+
+    const { error } = await admin.client.storage
+        .from(BUCKET)
+        .upload(key, file, {
+            contentType: file.type,
+            upsert: false,
+            cacheControl: '31536000',
+        });
+
+    if (error) {
+        console.error('Admin: image upload failed', { message: error.message });
+        const missingBucket = /bucket not found/i.test(error.message);
+        return NextResponse.json(
+            {
+                error: missingBucket
+                    ? `Storage bucket "${BUCKET}" was not found. Create a public bucket named "${BUCKET}" in Supabase Storage.`
+                    : 'Failed to upload image.',
+            },
+            { status: 502 },
+        );
+    }
+
+    const { data } = admin.client.storage.from(BUCKET).getPublicUrl(key);
+
+    return NextResponse.json(
+        { url: data.publicUrl, path: key },
+        { status: 200 },
+    );
+}

--- a/src/components/admin/ArticleEditor.tsx
+++ b/src/components/admin/ArticleEditor.tsx
@@ -29,6 +29,26 @@ function normalise(s: string) {
     return s.trim().toLowerCase();
 }
 
+/** Allowed image MIME types for upload (mirrors the server allowlist). */
+const ACCEPTED_IMAGE_TYPES = new Set([
+    'image/png',
+    'image/jpeg',
+    'image/webp',
+    'image/gif',
+    'image/avif',
+    'image/svg+xml',
+]);
+
+/**
+ * Derive a human-readable alt text from an uploaded filename: drop the
+ * extension and any directory parts, then turn separators into spaces.
+ */
+function altFromFilename(filename: string): string {
+    const base = filename.split(/[\\/]/).pop() ?? filename;
+    const noExt = base.replace(/\.[^.]+$/, '');
+    return noExt.replace(/[-_]+/g, ' ').trim();
+}
+
 /**
  * Shared admin article editor: form fields + a Markdown body editor with a live
  * preview rendered via the SAME {@link ArticleBody} component the public page
@@ -47,6 +67,10 @@ export default function ArticleEditor({ mode, article }: Props) {
     const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
     const [formError, setFormError] = useState<string | null>(null);
     const tagInputRef = useRef<HTMLInputElement>(null);
+    const bodyRef = useRef<HTMLTextAreaElement>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const [isUploading, setIsUploading] = useState(false);
+    const [uploadError, setUploadError] = useState<string | null>(null);
 
     const isSaving = createMutation.isPending || updateMutation.isPending;
     const currentStatus = article?.status ?? ArticleStatus.Draft;
@@ -89,6 +113,102 @@ export default function ArticleEditor({ mode, article }: Props) {
             ...prev,
             tags: prev.tags.filter((_, i) => i !== index),
         }));
+    }
+
+    /**
+     * Insert a Markdown image at the body textarea's caret (or append at the
+     * end with surrounding newlines when the caret position is unknown), then
+     * refocus the textarea with the caret after the inserted snippet.
+     */
+    function insertImageMarkdown(url: string, alt: string) {
+        const snippet = `![${alt}](${url})`;
+        const textarea = bodyRef.current;
+
+        setValues((prev) => {
+            const body = prev.body;
+            const hasSelection =
+                textarea !== null &&
+                typeof textarea.selectionStart === 'number' &&
+                typeof textarea.selectionEnd === 'number';
+
+            if (!hasSelection) {
+                const prefix =
+                    body.length > 0 && !body.endsWith('\n') ? '\n' : '';
+                const nextBody = `${body}${prefix}${snippet}\n`;
+                return { ...prev, body: nextBody };
+            }
+
+            const start = textarea.selectionStart;
+            const end = textarea.selectionEnd;
+            const nextBody = body.slice(0, start) + snippet + body.slice(end);
+
+            // Restore focus + caret after React commits the new value.
+            const caret = start + snippet.length;
+            requestAnimationFrame(() => {
+                textarea.focus();
+                textarea.setSelectionRange(caret, caret);
+            });
+
+            return { ...prev, body: nextBody };
+        });
+    }
+
+    async function uploadImage(file: File) {
+        if (!ACCEPTED_IMAGE_TYPES.has(file.type)) {
+            setUploadError(
+                'Unsupported image type. Use PNG, JPEG, WebP, GIF, AVIF, or SVG.',
+            );
+            return;
+        }
+
+        setUploadError(null);
+        setIsUploading(true);
+        try {
+            const formData = new FormData();
+            formData.append('file', file);
+            const res = await fetch('/api/admin/upload', {
+                method: 'POST',
+                body: formData,
+            });
+            const json = (await res.json()) as { url?: string; error?: string };
+            if (!res.ok || !json.url) {
+                setUploadError(json.error ?? 'Failed to upload image.');
+                return;
+            }
+            insertImageMarkdown(json.url, altFromFilename(file.name));
+        } catch {
+            setUploadError('Failed to upload image. Please try again.');
+        } finally {
+            setIsUploading(false);
+        }
+    }
+
+    function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+        const file = e.target.files?.[0];
+        // Reset so selecting the same file again re-triggers change.
+        e.target.value = '';
+        if (file) void uploadImage(file);
+    }
+
+    function handleBodyDrop(e: React.DragEvent<HTMLTextAreaElement>) {
+        const file = Array.from(e.dataTransfer.files).find((f) =>
+            f.type.startsWith('image/'),
+        );
+        if (file) {
+            e.preventDefault();
+            void uploadImage(file);
+        }
+    }
+
+    function handleBodyPaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
+        const item = Array.from(e.clipboardData.items).find((i) =>
+            i.type.startsWith('image/'),
+        );
+        const file = item?.getAsFile();
+        if (file) {
+            e.preventDefault();
+            void uploadImage(file);
+        }
     }
 
     function handleTagKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
@@ -275,24 +395,59 @@ export default function ArticleEditor({ mode, article }: Props) {
                     </div>
 
                     <div>
-                        <label
-                            htmlFor="article-body"
-                            className="block text-sm font-medium"
-                        >
-                            Body (Markdown){' '}
-                            <span className="text-red-500" aria-hidden="true">
-                                *
-                            </span>
-                        </label>
+                        <div className="flex items-center justify-between gap-2">
+                            <label
+                                htmlFor="article-body"
+                                className="block text-sm font-medium"
+                            >
+                                Body (Markdown){' '}
+                                <span
+                                    className="text-red-500"
+                                    aria-hidden="true"
+                                >
+                                    *
+                                </span>
+                            </label>
+                            <button
+                                type="button"
+                                className="btn btn--outline min-h-0 px-3 py-1 text-xs"
+                                disabled={isUploading}
+                                onClick={() => fileInputRef.current?.click()}
+                            >
+                                {isUploading ? 'Uploading…' : 'Upload image'}
+                            </button>
+                            <input
+                                ref={fileInputRef}
+                                type="file"
+                                accept="image/*"
+                                className="hidden"
+                                onChange={handleFileChange}
+                            />
+                        </div>
                         <textarea
                             id="article-body"
+                            ref={bodyRef}
                             className="mt-1 w-full form-input font-mono text-sm"
                             rows={20}
                             value={values.body}
                             onChange={(e) => setField('body', e.target.value)}
+                            onDrop={handleBodyDrop}
+                            onPaste={handleBodyPaste}
                             aria-invalid={Boolean(fieldErrors.body)}
                             spellCheck
                         />
+                        <p className="mt-1 text-xs text-[var(--color-norwegian-500)] dark:text-[var(--color-norwegian-400)]">
+                            Upload, drag-and-drop, or paste an image to insert
+                            it at the cursor.
+                        </p>
+                        {uploadError ? (
+                            <p
+                                className="mt-1 text-xs text-red-600"
+                                role="alert"
+                            >
+                                {uploadError}
+                            </p>
+                        ) : null}
                         {fieldErrors.body ? (
                             <p className="mt-1 text-xs text-red-600" role="alert">
                                 {fieldErrors.body}

--- a/src/components/admin/__tests__/ArticleEditor.upload.test.tsx
+++ b/src/components/admin/__tests__/ArticleEditor.upload.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// Keep the editor test focused on upload-and-insert: stub the data hook,
+// the router, and the heavy Markdown preview.
+vi.mock('@/lib/hooks/useAdminArticles', () => ({
+    useAdminArticles: () => ({
+        createMutation: { isPending: false, mutateAsync: vi.fn() },
+        updateMutation: { isPending: false, mutateAsync: vi.fn() },
+    }),
+}));
+
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock('@/components/ArticleBody', () => ({
+    default: ({ body }: { body: string }) => (
+        <div data-testid="preview">{body}</div>
+    ),
+}));
+
+import ArticleEditor from '../ArticleEditor';
+
+function getBody() {
+    return screen.getByLabelText(/Body \(Markdown\)/) as HTMLTextAreaElement;
+}
+
+describe('ArticleEditor image upload', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('uploads a chosen file and inserts the Markdown image at the cursor', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                url: 'https://storage.example.com/article-assets/2026/abc.png',
+            }),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        render(<ArticleEditor mode="create" />);
+
+        const body = getBody();
+        fireEvent.change(body, { target: { value: 'before after' } });
+        body.setSelectionRange(6, 6); // caret between "before " and "after"
+
+        const file = new File(['x'], 'my-cool_pic.png', { type: 'image/png' });
+        const input = document.querySelector(
+            'input[type="file"]',
+        ) as HTMLInputElement;
+        fireEvent.change(input, { target: { files: [file] } });
+
+        await waitFor(() => {
+            expect(fetchMock).toHaveBeenCalledWith(
+                '/api/admin/upload',
+                expect.objectContaining({ method: 'POST' }),
+            );
+        });
+
+        await waitFor(() => {
+            // Alt text derived from filename (extension dropped, separators -> spaces).
+            expect(body.value).toContain(
+                '![my cool pic](https://storage.example.com/article-assets/2026/abc.png)',
+            );
+        });
+        // Inserted at the caret, between the two words.
+        expect(body.value.startsWith('before')).toBe(true);
+        expect(body.value.trimEnd().endsWith('after')).toBe(true);
+    });
+
+    it('surfaces the server error message and inserts nothing on failure', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: false,
+            json: async () => ({ error: 'Image is too large (max 5 MB).' }),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        render(<ArticleEditor mode="create" />);
+
+        const file = new File(['x'], 'big.png', { type: 'image/png' });
+        const input = document.querySelector(
+            'input[type="file"]',
+        ) as HTMLInputElement;
+        fireEvent.change(input, { target: { files: [file] } });
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('Image is too large (max 5 MB).'),
+            ).toBeInTheDocument();
+        });
+        expect(getBody().value).toBe('');
+    });
+});


### PR DESCRIPTION
## What

Admin image upload for articles, stored in **Supabase Storage**.

- `POST /api/admin/upload` — `requireAdmin`-gated. Validates the image, stores it in the public `article-assets` bucket, returns the public URL.
- `ArticleEditor` — an **Upload image** button, plus **drag-and-drop** onto the body and **paste** from clipboard. On success it inserts `![alt](url)` at the cursor (alt derived from the filename) and the live preview renders it immediately.

## Security

- **Authorization first.** `requireAdmin()` runs before any storage access, so a non-admin can never reach the service-role (RLS-bypassing) client. A test asserts the guard returns *and* the service-role client is never constructed for non-admins.
- **Server-controlled object key.** `${year}/${randomUUID()}.${ext}`, where `ext` comes from the **validated MIME** (allowlist), never the user filename — so the key can't contain the original name, `..`, or a leading slash. `upsert: false` makes overwrite impossible.
- **Server-side validation** (client not trusted): MIME allowlist (`png/jpeg/webp/gif/avif/svg+xml`) + 5 MB cap.
- SVGs are admin-only/trusted, served from the separate Supabase Storage origin and embedded via script-sandboxed `<img>`, so no server-side SVG sanitization is needed.

## Setup required before use

1. Create a **public** Supabase Storage bucket named **`article-assets`** (Dashboard → Storage → New bucket → Public). Until it exists, uploads return a clear *"bucket not found"* error.
2. **No new env var** — reuses the existing `SUPABASE_SECRET_KEY`.

## Server / infra

- **MCP server: no changes.** The article body stores the returned URL (existing string field) — no endpoints, schema, or client regen.
- **Supabase:** the one public bucket above.

## Tests

Route: non-admin guard, 503 (unconfigured), 400 (missing / bad type / oversize), 200 happy path, traversal-safe key. Editor: file selection uploads and inserts the Markdown. Full suite green (286).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
