### PR TITLE
feat: /writing section rename + nav restructure + reusable Card

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,23 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  // The articles section was renamed from /philosophy to /writing. Old URLs
+  // (which have published, indexed articles like /philosophy/cptsd) must keep
+  // working, so permanently (308) redirect them to their /writing equivalents.
+  async redirects() {
+    return [
+      {
+        source: "/philosophy",
+        destination: "/writing",
+        permanent: true,
+      },
+      {
+        source: "/philosophy/:slug*",
+        destination: "/writing/:slug*",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/__tests__/feeds.test.ts
+++ b/src/app/__tests__/feeds.test.ts
@@ -33,10 +33,10 @@ describe('sitemap', () => {
         const { default: sitemap } = await import('@/app/sitemap');
         const entries = await sitemap();
         const urls = entries.map((e) => e.url);
-        expect(urls).toContain('https://bryandebaun.dev/philosophy');
-        expect(urls).toContain('https://bryandebaun.dev/philosophy/cptsd');
+        expect(urls).toContain('https://bryandebaun.dev/writing');
+        expect(urls).toContain('https://bryandebaun.dev/writing/cptsd');
         const cptsd = entries.find(
-            (e) => e.url === 'https://bryandebaun.dev/philosophy/cptsd',
+            (e) => e.url === 'https://bryandebaun.dev/writing/cptsd',
         );
         expect(cptsd?.lastModified).toEqual(
             new Date('2026-02-01T00:00:00.000Z'),
@@ -51,21 +51,21 @@ describe('sitemap', () => {
         expect(urls).toContain('https://bryandebaun.dev/about');
         expect(
             urls.some((u) =>
-                u.startsWith('https://bryandebaun.dev/philosophy/'),
+                u.startsWith('https://bryandebaun.dev/writing/'),
             ),
         ).toBe(false);
     });
 });
 
 describe('rss.xml route', () => {
-    it('renders published articles under the philosophy path', async () => {
+    it('renders published articles under the writing path', async () => {
         const { GET } = await import('@/app/rss.xml/route');
         const res = await GET();
         expect(res.headers.get('Content-Type')).toBe('application/xml');
         const xml = await res.text();
         expect(xml).toContain('<title>CPTSD</title>');
         expect(xml).toContain(
-            '<link>https://bryandebaun.dev/philosophy/cptsd</link>',
+            '<link>https://bryandebaun.dev/writing/cptsd</link>',
         );
     });
 

--- a/src/app/__tests__/redirects.test.ts
+++ b/src/app/__tests__/redirects.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import nextConfig from '../../../next.config';
+
+/**
+ * The articles section was renamed from /philosophy to /writing. Old URLs are
+ * indexed and have published articles, so the Next config must permanently
+ * (308) redirect both the index and any slug path to the /writing equivalent.
+ */
+describe('next.config redirects', () => {
+    it('permanently redirects the old philosophy URLs to writing', async () => {
+        expect(typeof nextConfig.redirects).toBe('function');
+        const rules = await nextConfig.redirects?.();
+        expect(rules).toEqual(
+            expect.arrayContaining([
+                {
+                    source: '/philosophy',
+                    destination: '/writing',
+                    permanent: true,
+                },
+                {
+                    source: '/philosophy/:slug*',
+                    destination: '/writing/:slug*',
+                    permanent: true,
+                },
+            ]),
+        );
+    });
+});

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -46,6 +46,25 @@ export default function About() {
                 </Link>{' '}
                 page.
             </p>
+
+            <h3>Get in touch</h3>
+            <p>
+                Want to reach out? You can get in touch via the{' '}
+                <Link
+                    href="/contact"
+                    className="text-[var(--color-norwegian-700)] hover:underline dark:text-[var(--color-white)]"
+                >
+                    Contact
+                </Link>{' '}
+                page, or see my{' '}
+                <Link
+                    href="/resume"
+                    className="text-[var(--color-norwegian-700)] hover:underline dark:text-[var(--color-white)]"
+                >
+                    Resume
+                </Link>
+                .
+            </p>
         </div>
     );
 }

--- a/src/app/api/admin/articles/[slug]/__tests__/route.test.ts
+++ b/src/app/api/admin/articles/[slug]/__tests__/route.test.ts
@@ -72,7 +72,7 @@ describe('PUT /api/admin/articles/[slug]', () => {
         expect(updateArticle).toHaveBeenCalledWith('cptsd', {
             status: 'published',
         });
-        expect(revalidatePath).toHaveBeenCalledWith('/philosophy/cptsd');
+        expect(revalidatePath).toHaveBeenCalledWith('/writing/cptsd');
     });
 
     it('revalidates both old and new slug on a rename', async () => {
@@ -84,8 +84,8 @@ describe('PUT /api/admin/articles/[slug]', () => {
         await route.PUT(req as unknown as NextRequest, {
             params: { slug: 'old' },
         });
-        expect(revalidatePath).toHaveBeenCalledWith('/philosophy/new');
-        expect(revalidatePath).toHaveBeenCalledWith('/philosophy/old');
+        expect(revalidatePath).toHaveBeenCalledWith('/writing/new');
+        expect(revalidatePath).toHaveBeenCalledWith('/writing/old');
     });
 
     it('surfaces a slug conflict as a 400 field error', async () => {
@@ -145,8 +145,8 @@ describe('DELETE /api/admin/articles/[slug]', () => {
         });
         expect((res as Response).status).toBe(204);
         expect(deleteArticle).toHaveBeenCalledWith('cptsd');
-        expect(revalidatePath).toHaveBeenCalledWith('/philosophy');
-        expect(revalidatePath).toHaveBeenCalledWith('/philosophy/cptsd');
+        expect(revalidatePath).toHaveBeenCalledWith('/writing');
+        expect(revalidatePath).toHaveBeenCalledWith('/writing/cptsd');
     });
 
     it('returns 401 when not authenticated', async () => {

--- a/src/app/api/admin/articles/[slug]/route.ts
+++ b/src/app/api/admin/articles/[slug]/route.ts
@@ -23,7 +23,7 @@ type RouteContext = {
  *
  * Updates an article (title/body/summary/tags, `status` transitions such as
  * publish/unpublish, `publishedAt`, and `newSlug` renames). On success the
- * public philosophy paths are revalidated — both the old and the new slug when
+ * public writing paths are revalidated — both the old and the new slug when
  * a rename occurs — so publish/unpublish is reflected immediately.
  */
 export async function PUT(req: NextRequest, context: RouteContext) {
@@ -63,7 +63,7 @@ export async function PUT(req: NextRequest, context: RouteContext) {
 /**
  * DELETE /api/admin/articles/[slug]
  *
- * Deletes an article and revalidates the public philosophy paths so the
+ * Deletes an article and revalidates the public writing paths so the
  * removed article disappears from the index and 404s on its slug page.
  */
 export async function DELETE(_req: NextRequest, context: RouteContext) {

--- a/src/app/api/admin/articles/__tests__/route.test.ts
+++ b/src/app/api/admin/articles/__tests__/route.test.ts
@@ -113,8 +113,8 @@ describe('POST /api/admin/articles', () => {
         expect((res as Response).status).toBe(201);
         const json = await (res as Response).json();
         expect(json.slug).toBe('new-one');
-        expect(revalidatePath).toHaveBeenCalledWith('/philosophy');
-        expect(revalidatePath).toHaveBeenCalledWith('/philosophy/new-one');
+        expect(revalidatePath).toHaveBeenCalledWith('/writing');
+        expect(revalidatePath).toHaveBeenCalledWith('/writing/new-one');
     });
 
     it('surfaces a slug conflict as a 400 field error', async () => {

--- a/src/app/api/admin/articles/route.ts
+++ b/src/app/api/admin/articles/route.ts
@@ -55,7 +55,7 @@ export async function GET() {
  *
  * Creates a new article. A duplicate slug is surfaced as a clean 400 field
  * error so the editor can show it inline. On success we revalidate the public
- * philosophy paths so a freshly-published article appears without waiting out
+ * writing paths so a freshly-published article appears without waiting out
  * the ISR window.
  */
 export async function POST(req: NextRequest) {

--- a/src/app/api/revalidate/__tests__/route.test.ts
+++ b/src/app/api/revalidate/__tests__/route.test.ts
@@ -66,7 +66,7 @@ describe('POST /api/revalidate', () => {
         );
         expect(res.status).toBe(200);
         await expect(res.json()).resolves.toEqual({ revalidated: true });
-        expect(revalidatePath).toHaveBeenCalledWith('/philosophy');
+        expect(revalidatePath).toHaveBeenCalledWith('/writing');
         expect(revalidatePath).toHaveBeenCalledTimes(1);
     });
 
@@ -80,8 +80,8 @@ describe('POST /api/revalidate', () => {
             ),
         );
         expect(res.status).toBe(200);
-        expect(revalidatePath).toHaveBeenCalledWith('/philosophy');
-        expect(revalidatePath).toHaveBeenCalledWith('/philosophy/cptsd');
+        expect(revalidatePath).toHaveBeenCalledWith('/writing');
+        expect(revalidatePath).toHaveBeenCalledWith('/writing/cptsd');
     });
 
     it('accepts the secret via the ?secret= query param', async () => {
@@ -89,6 +89,6 @@ describe('POST /api/revalidate', () => {
         const { POST } = await import('../route');
         const res = await POST(makeReq({}, { query: `?secret=${SECRET}` }));
         expect(res.status).toBe(200);
-        expect(revalidatePath).toHaveBeenCalledWith('/philosophy');
+        expect(revalidatePath).toHaveBeenCalledWith('/writing');
     });
 });

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -5,7 +5,7 @@ import { NextResponse, type NextRequest } from 'next/server';
  * Secret-protected on-demand revalidation hook.
  *
  * The MCP server (or an admin tool) POSTs here after publishing/updating an
- * article so the philosophy list — and, if a slug is provided, the matching
+ * article so the writing list — and, if a slug is provided, the matching
  * detail page — refresh immediately instead of waiting for the ISR window.
  *
  * Security model:
@@ -41,9 +41,9 @@ export async function POST(req: NextRequest) {
         // Body is optional — a bare POST revalidates the list only.
     }
 
-    revalidatePath('/philosophy');
+    revalidatePath('/writing');
     if (slug) {
-        revalidatePath(`/philosophy/${slug}`);
+        revalidatePath(`/writing/${slug}`);
     }
 
     return NextResponse.json({ revalidated: true });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -300,6 +300,17 @@ a:focus-visible {
   text-decoration-thickness: 2px;
 }
 
+/* Links that opt out via `.no-underline` (e.g. whole-surface cards) stay
+   un-underlined at rest, on hover, AND on focus. This is unlayered and uses
+   class specificity so it beats the rule above AND any layered prose/utility
+   styling — under Tailwind v4 cascade layers the layered `no-underline` utility
+   alone loses to unlayered link rules. */
+a.no-underline,
+a.no-underline:hover,
+a.no-underline:focus-visible {
+  text-decoration: none;
+}
+
 .site-nav a:hover {
   color: var(--color-fjord-600);
 }

--- a/src/app/projects/__tests__/page.test.tsx
+++ b/src/app/projects/__tests__/page.test.tsx
@@ -23,12 +23,14 @@ describe('Projects page static checks', () => {
         expect(src).not.toContain('whitespace-nowrap');
     });
 
-    it('RepoCard handles overflow with min-w-0/truncate and clamps the description', () => {
+    it('Card handles overflow with min-w-0/truncate and clamps the description', () => {
+        // RepoCard now delegates its presentation to the generic Card
+        // component, so the overflow-handling classes live there.
         const filePath = path.resolve(
             process.cwd(),
             'src',
             'components',
-            'RepoCard.tsx',
+            'Card.tsx',
         );
         const src = readFileSync(filePath, 'utf8');
         expect(src).toContain('min-w-0');

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -88,7 +88,7 @@ export default function ResumePage() {
 
     // schema.org Person, embedded in a ProfilePage. Emitted as JSON-LD for
     // search engines / rich results. Mirrors the JSON-LD pattern used by the
-    // philosophy slug page.
+    // writing slug page.
     const jsonLd = {
         '@context': 'https://schema.org',
         '@type': 'ProfilePage',

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -3,11 +3,11 @@ import { generateRSS } from '@/lib/rss';
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://bryandebaun.dev';
 
-// ISR: refresh the feed on the same cadence as the philosophy pages.
+// ISR: refresh the feed on the same cadence as the writing pages.
 export const revalidate = 300;
 
 /**
- * RSS feed for published philosophy articles, sourced from the MCP Articles
+ * RSS feed for published writing articles, sourced from the MCP Articles
  * API. The API returns only `published` articles for unauthenticated reads, so
  * no private filtering is required.
  */
@@ -15,7 +15,7 @@ export async function GET(): Promise<Response> {
     const articles = await listPublishedArticles();
     const items = articles.map((article) => ({
         title: article.title,
-        slug: `philosophy/${article.slug}`,
+        slug: `writing/${article.slug}`,
     }));
 
     const xml = generateRSS(SITE_URL, items);

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -12,7 +12,7 @@ const STATIC_PATHS = [
     '', // home
     '/about',
     '/projects',
-    '/philosophy',
+    '/writing',
     '/media',
     '/books',
     '/authors',
@@ -22,7 +22,7 @@ const STATIC_PATHS = [
 /**
  * App Router sitemap. Next renders this `MetadataRoute.Sitemap` array to XML.
  *
- * Philosophy entries are sourced from the MCP Articles API and are inherently
+ * Writing entries are sourced from the MCP Articles API and are inherently
  * public-only (the API returns `published` articles for unauthenticated reads),
  * so no `publicOnly` filtering is needed here anymore.
  */
@@ -33,7 +33,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
     const articles = await listPublishedArticles();
     const articleEntries: MetadataRoute.Sitemap = articles.map((article) => ({
-        url: `${SITE_URL}/philosophy/${article.slug}`,
+        url: `${SITE_URL}/writing/${article.slug}`,
         lastModified: article.updatedAt
             ? new Date(article.updatedAt)
             : undefined,

--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -41,7 +41,7 @@ export async function generateMetadata({
     const title = `${article.title} — Bryan DeBaun`;
     const description =
         article.summary ?? `${article.title} — a note by Bryan DeBaun.`;
-    const url = `${SITE_URL}/philosophy/${article.slug}`;
+    const url = `${SITE_URL}/writing/${article.slug}`;
 
     return {
         title,
@@ -70,7 +70,7 @@ export default async function PhilosophyPage({
         notFound();
     }
 
-    const url = `${SITE_URL}/philosophy/${article.slug}`;
+    const url = `${SITE_URL}/writing/${article.slug}`;
     const jsonLd = {
         '@context': 'https://schema.org',
         '@type': 'BlogPosting',

--- a/src/app/writing/__tests__/page.test.tsx
+++ b/src/app/writing/__tests__/page.test.tsx
@@ -38,30 +38,30 @@ afterEach(() => {
     vi.resetModules();
 });
 
-describe('Philosophy list page', () => {
+describe('Writing list page', () => {
     it('renders a published article link and summary', async () => {
         listPublishedArticles.mockResolvedValue([article]);
-        const { default: Philosophy } = await import('../page');
-        render(await Philosophy());
+        const { default: Writing } = await import('../page');
+        render(await Writing());
         const link = screen.getByRole('link', { name: 'CPTSD — Thoughts' });
-        expect(link).toHaveAttribute('href', '/philosophy/cptsd');
+        expect(link).toHaveAttribute('href', '/writing/cptsd');
         expect(screen.getByText('A living document.')).toBeInTheDocument();
     });
 
     it('shows an empty state when there are no articles', async () => {
         listPublishedArticles.mockResolvedValue([]);
-        const { default: Philosophy } = await import('../page');
-        render(await Philosophy());
+        const { default: Writing } = await import('../page');
+        render(await Writing());
         expect(screen.getByText('No notes yet.')).toBeInTheDocument();
     });
 });
 
-describe('Philosophy detail page', () => {
+describe('Writing detail page', () => {
     it('renders the title once and the article body', async () => {
         getArticleBySlug.mockResolvedValue(article);
-        const { default: PhilosophyPage } = await import('../[slug]/page');
+        const { default: WritingPage } = await import('../[slug]/page');
         render(
-            await PhilosophyPage({
+            await WritingPage({
                 params: Promise.resolve({ slug: 'cptsd' }),
             }),
         );
@@ -76,9 +76,9 @@ describe('Philosophy detail page', () => {
 
     it('calls notFound() when the article is missing', async () => {
         getArticleBySlug.mockResolvedValue(null);
-        const { default: PhilosophyPage } = await import('../[slug]/page');
+        const { default: WritingPage } = await import('../[slug]/page');
         await expect(
-            PhilosophyPage({ params: Promise.resolve({ slug: 'missing' }) }),
+            WritingPage({ params: Promise.resolve({ slug: 'missing' }) }),
         ).rejects.toThrow('NEXT_NOT_FOUND');
         expect(notFound).toHaveBeenCalled();
     });

--- a/src/app/writing/__tests__/page.test.tsx
+++ b/src/app/writing/__tests__/page.test.tsx
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
-const listPublishedArticles = vi.fn();
+const listRecentPublishedArticles = vi.fn();
 const getArticleBySlug = vi.fn();
 vi.mock('@/lib/services/articles', () => ({
-    listPublishedArticles: () => listPublishedArticles(),
+    listRecentPublishedArticles: () => listRecentPublishedArticles(),
     getArticleBySlug: (slug: string) => getArticleBySlug(slug),
 }));
 
@@ -29,7 +29,7 @@ const article = {
 };
 
 beforeEach(() => {
-    listPublishedArticles.mockReset();
+    listRecentPublishedArticles.mockReset();
     getArticleBySlug.mockReset();
     notFound.mockClear();
 });
@@ -39,17 +39,20 @@ afterEach(() => {
 });
 
 describe('Writing list page', () => {
-    it('renders a published article link and summary', async () => {
-        listPublishedArticles.mockResolvedValue([article]);
+    it('renders a published article card with title and summary', async () => {
+        listRecentPublishedArticles.mockResolvedValue([article]);
         const { default: Writing } = await import('../page');
         render(await Writing());
-        const link = screen.getByRole('link', { name: 'CPTSD — Thoughts' });
+        const link = screen.getByRole('link', { name: /CPTSD — Thoughts/ });
         expect(link).toHaveAttribute('href', '/writing/cptsd');
+        expect(
+            screen.getByRole('heading', { name: 'CPTSD — Thoughts' }),
+        ).toBeInTheDocument();
         expect(screen.getByText('A living document.')).toBeInTheDocument();
     });
 
     it('shows an empty state when there are no articles', async () => {
-        listPublishedArticles.mockResolvedValue([]);
+        listRecentPublishedArticles.mockResolvedValue([]);
         const { default: Writing } = await import('../page');
         render(await Writing());
         expect(screen.getByText('No notes yet.')).toBeInTheDocument();

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
-import { listPublishedArticles } from '@/lib/services/articles';
+import Card from '@/components/Card';
+import { listRecentPublishedArticles } from '@/lib/services/articles';
 import { formatDate } from '@/lib/dates';
 
 export const metadata: Metadata = {
@@ -14,34 +14,29 @@ export const metadata: Metadata = {
 export const revalidate = 300;
 
 export default async function Philosophy() {
-    const posts = await listPublishedArticles();
+    const posts = await listRecentPublishedArticles();
     return (
         <div className="prose prose-norwegian dark:prose-invert">
             <h2>Philosophy & Thoughts</h2>
             {posts.length === 0 ? (
                 <p>No notes yet.</p>
             ) : (
-                <ul className="list-none pl-0">
+                <ul className="not-prose grid grid-cols-1 md:grid-cols-2 gap-4 list-none p-0">
                     {posts.map((p) => (
-                        <li key={p.id}>
-                            <Link href={`/writing/${p.slug}`}>
-                                {p.title}
-                            </Link>
-                            {p.summary ? (
-                                <div className="text-sm">{p.summary}</div>
-                            ) : null}
-                            {p.publishedAt ? (
-                                <div className="text-sm text-muted">
-                                    {formatDate(p.publishedAt, {
-                                        month: 'long',
-                                    })}
-                                </div>
-                            ) : null}
-                            {p.tags.length > 0 ? (
-                                <div className="text-sm text-muted">
-                                    {p.tags.join(' · ')}
-                                </div>
-                            ) : null}
+                        <li key={p.id} className="min-w-0">
+                            <Card
+                                href={`/writing/${p.slug}`}
+                                title={p.title}
+                                description={p.summary}
+                                chips={p.tags}
+                                meta={
+                                    p.publishedAt
+                                        ? formatDate(p.publishedAt, {
+                                              month: 'long',
+                                          })
+                                        : undefined
+                                }
+                            />
                         </li>
                     ))}
                 </ul>

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -24,7 +24,7 @@ export default async function Philosophy() {
                 <ul className="list-none pl-0">
                     {posts.map((p) => (
                         <li key={p.id}>
-                            <Link href={`/philosophy/${p.slug}`}>
+                            <Link href={`/writing/${p.slug}`}>
                                 {p.title}
                             </Link>
                             {p.summary ? (

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,88 @@
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+
+export interface CardProps {
+    href: string;
+    title: string;
+    description?: string | null;
+    chips?: string[];
+    external?: boolean;
+    icon?: ReactNode;
+    meta?: ReactNode;
+    ariaLabel?: string;
+}
+
+const CARD_CLASS =
+    'group flex h-full min-w-0 flex-col gap-3 rounded-xl border border-[var(--color-norwegian-300)] bg-[var(--background)] p-5 no-underline shadow-sm transition-shadow transition-transform duration-150 ease-out transform-gpu hover:border-[var(--color-fjord-600)] hover:shadow-md motion-safe:hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-fjord-600)] dark:border-[var(--color-norwegian-300-dark)] dark:hover:border-[var(--color-fjord-neon)]';
+
+/**
+ * Generic, presentational card whose entire surface is the link. Used for
+ * project repositories (external) and article/writing entries (internal).
+ *
+ * Layout: a title row (optional icon + title), then an optional clamped
+ * description, then optional meta line, then up to five rounded-full chips.
+ */
+export default function Card({
+    href,
+    title,
+    description,
+    chips,
+    external = false,
+    icon,
+    meta,
+    ariaLabel,
+}: CardProps) {
+    const inner = (
+        <>
+            <div className="flex items-center gap-2">
+                {icon}
+                <h3 className="m-0 min-w-0 break-words text-base font-semibold leading-snug text-[var(--color-norwegian-700)] dark:text-[var(--color-white)]">
+                    {title}
+                </h3>
+            </div>
+
+            {description ? (
+                <p className="m-0 line-clamp-3 text-sm leading-relaxed text-[var(--color-norwegian-700)] opacity-90 dark:text-[var(--color-norwegian-200)]">
+                    {description}
+                </p>
+            ) : null}
+
+            {meta ? (
+                <div className="text-sm text-muted">{meta}</div>
+            ) : null}
+
+            {chips && chips.length > 0 ? (
+                <ul className="mt-auto flex list-none flex-wrap gap-2 p-0">
+                    {chips.slice(0, 5).map((chip) => (
+                        <li
+                            key={chip}
+                            className="max-w-[10rem] truncate rounded-full border border-[var(--color-norwegian-300)] bg-[var(--color-norwegian-100)] px-2.5 py-0.5 text-xs font-medium text-[var(--color-norwegian-700)] dark:border-[var(--color-norwegian-300-dark)] dark:bg-[color-mix(in_srgb,var(--color-fjord-600)_18%,transparent)] dark:text-[var(--color-norwegian-200)]"
+                        >
+                            {chip}
+                        </li>
+                    ))}
+                </ul>
+            ) : null}
+        </>
+    );
+
+    if (external) {
+        return (
+            <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={ariaLabel}
+                className={CARD_CLASS}
+            >
+                {inner}
+            </a>
+        );
+    }
+
+    return (
+        <Link href={href} aria-label={ariaLabel} className={CARD_CLASS}>
+            {inner}
+        </Link>
+    );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -183,11 +183,11 @@ export default function Header() {
                     <Link href="/projects" className="text-sm">
                         Projects
                     </Link>
-                    <Link href="/contact" className="text-sm">
-                        Contact
+                    <Link href="/media" className="text-sm">
+                        Media
                     </Link>
-                    <Link href="/resume" className="text-sm">
-                        Resume
+                    <Link href="/writing" className="text-sm">
+                        Writings
                     </Link>
                     <DarkModeToggle />
                     <AuthStatus />
@@ -263,20 +263,20 @@ export default function Header() {
                         Projects
                     </Link>
                     <Link
-                        href="/contact"
-                        id="mobile-nav-contact"
+                        href="/media"
+                        id="mobile-nav-media"
                         className="inline-block px-3 py-3 rounded text-sm text-center uppercase font-semibold tracking-wide"
                         role="menuitem"
                     >
-                        Contact
+                        Media
                     </Link>
                     <Link
-                        href="/resume"
-                        id="mobile-nav-resume"
+                        href="/writing"
+                        id="mobile-nav-writings"
                         className="inline-block px-3 py-3 rounded text-sm text-center uppercase font-semibold tracking-wide"
                         role="menuitem"
                     >
-                        Resume
+                        Writings
                     </Link>
                     <div className="px-3 py-2">
                         <AuthStatus />

--- a/src/components/PhilosophyList.tsx
+++ b/src/components/PhilosophyList.tsx
@@ -14,7 +14,7 @@ export default async function PhilosophyList({
             <ul className="list-none pl-0">
                 {posts.map((p) => (
                     <li key={p.id}>
-                        <Link href={`/philosophy/${p.slug}`}>{p.title}</Link>
+                        <Link href={`/writing/${p.slug}`}>{p.title}</Link>
                         {p.summary ? (
                             <div className="text-sm">{p.summary}</div>
                         ) : null}

--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -1,4 +1,5 @@
 import type { Repo } from '../lib/github';
+import Card from './Card';
 
 /**
  * Format a raw GitHub repo name into a brand-safe, human-readable title.
@@ -20,55 +21,35 @@ export function formatRepoName(name: string): string {
     return s;
 }
 
+function GitHubSvg() {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            className="h-5 w-5 flex-shrink-0 text-[var(--color-fjord-600)] dark:text-[var(--color-fjord-neon)]"
+            aria-hidden="true"
+        >
+            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.58.82-2.14-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.14 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38C13.71 14.53 16 11.54 16 8c0-4.42-3.58-8-8-8z" />
+        </svg>
+    );
+}
+
 /**
  * A single project rendered as a responsive card. The whole card is the link
  * to the repository. Topic chips fall back to nothing when no topics/language
  * are available in the data shape.
  */
 export default function RepoCard({ repo }: { repo: Repo }) {
-    const chips = repo.topics ?? [];
-
     return (
-        <a
+        <Card
+            external
+            icon={<GitHubSvg />}
+            title={formatRepoName(repo.name)}
+            description={repo.description}
+            chips={repo.topics ?? []}
+            ariaLabel={`${repo.name} — ${repo.description ?? 'Repository'}`}
             href={repo.html_url}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label={`${repo.name} — ${repo.description ?? 'Repository'}`}
-            className="group flex h-full min-w-0 flex-col gap-3 rounded-xl border border-[var(--color-norwegian-300)] bg-[var(--background)] p-5 no-underline shadow-sm transition-shadow transition-transform duration-150 ease-out transform-gpu hover:border-[var(--color-fjord-600)] hover:shadow-md motion-safe:hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-fjord-600)] dark:border-[var(--color-norwegian-300-dark)] dark:hover:border-[var(--color-fjord-neon)]"
-        >
-            <div className="flex items-center gap-2">
-                <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 16 16"
-                    fill="currentColor"
-                    className="h-5 w-5 flex-shrink-0 text-[var(--color-fjord-600)] dark:text-[var(--color-fjord-neon)]"
-                    aria-hidden="true"
-                >
-                    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.58.82-2.14-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.14 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38C13.71 14.53 16 11.54 16 8c0-4.42-3.58-8-8-8z" />
-                </svg>
-                <h3 className="m-0 min-w-0 break-words text-base font-semibold leading-snug text-[var(--color-norwegian-700)] dark:text-[var(--color-white)]">
-                    {formatRepoName(repo.name)}
-                </h3>
-            </div>
-
-            {repo.description ? (
-                <p className="m-0 line-clamp-3 text-sm leading-relaxed text-[var(--color-norwegian-700)] opacity-90 dark:text-[var(--color-norwegian-200)]">
-                    {repo.description}
-                </p>
-            ) : null}
-
-            {chips.length > 0 ? (
-                <ul className="mt-auto flex list-none flex-wrap gap-2 p-0">
-                    {chips.slice(0, 5).map((chip) => (
-                        <li
-                            key={chip}
-                            className="max-w-[10rem] truncate rounded-full border border-[var(--color-norwegian-300)] bg-[var(--color-norwegian-100)] px-2.5 py-0.5 text-xs font-medium text-[var(--color-norwegian-700)] dark:border-[var(--color-norwegian-300-dark)] dark:bg-[color-mix(in_srgb,var(--color-fjord-600)_18%,transparent)] dark:text-[var(--color-norwegian-200)]"
-                        >
-                            {chip}
-                        </li>
-                    ))}
-                </ul>
-            ) : null}
-        </a>
+        />
     );
 }

--- a/src/components/__tests__/Card.test.tsx
+++ b/src/components/__tests__/Card.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Card from '../Card';
+
+describe('Card', () => {
+    it('renders an internal next/link with no target', () => {
+        render(<Card href="/writing/cptsd" title="CPTSD" />);
+        const link = screen.getByRole('link', { name: 'CPTSD' });
+        expect(link).toHaveAttribute('href', '/writing/cptsd');
+        expect(link).not.toHaveAttribute('target');
+    });
+
+    it('renders an external anchor with target and rel', () => {
+        render(
+            <Card
+                external
+                href="https://example.com/repo"
+                title="Repo"
+                ariaLabel="Repo — desc"
+            />,
+        );
+        const link = screen.getByRole('link', { name: 'Repo — desc' });
+        expect(link).toHaveAttribute('href', 'https://example.com/repo');
+        expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('renders title, description, meta, and chips', () => {
+        render(
+            <Card
+                href="/x"
+                title="Title here"
+                description="A description."
+                meta="January 2026"
+                chips={['a', 'b', 'c']}
+            />,
+        );
+        expect(
+            screen.getByRole('heading', { name: 'Title here' }),
+        ).toBeInTheDocument();
+        expect(screen.getByText('A description.')).toBeInTheDocument();
+        expect(screen.getByText('January 2026')).toBeInTheDocument();
+        expect(screen.getByText('a')).toBeInTheDocument();
+        expect(screen.getByText('b')).toBeInTheDocument();
+        expect(screen.getByText('c')).toBeInTheDocument();
+    });
+
+    it('caps chips at five', () => {
+        render(
+            <Card
+                href="/x"
+                title="T"
+                chips={['1', '2', '3', '4', '5', '6', '7']}
+            />,
+        );
+        expect(screen.getAllByRole('listitem')).toHaveLength(5);
+        expect(screen.queryByText('6')).not.toBeInTheDocument();
+    });
+
+    it('omits description and chips when not provided', () => {
+        render(<Card href="/x" title="T" />);
+        expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    });
+});

--- a/src/components/admin/ArticleEditor.tsx
+++ b/src/components/admin/ArticleEditor.tsx
@@ -328,7 +328,7 @@ export default function ArticleEditor({ mode, article }: Props) {
                             autoComplete="off"
                         />
                         <p className="mt-1 text-xs text-[var(--color-norwegian-500)] dark:text-[var(--color-norwegian-400)]">
-                            Lives at <code>/philosophy/{values.slug || '…'}</code>
+                            Lives at <code>/writing/{values.slug || '…'}</code>
                         </p>
                         {fieldErrors.slug ? (
                             <p className="mt-1 text-xs text-red-600" role="alert">

--- a/src/lib/__tests__/admin-articles.test.ts
+++ b/src/lib/__tests__/admin-articles.test.ts
@@ -20,16 +20,16 @@ describe('revalidateArticlePaths', () => {
     it('revalidates the index and the slug page', () => {
         const spy = vi.fn();
         revalidateArticlePaths(spy, 'cptsd');
-        expect(spy).toHaveBeenCalledWith('/philosophy');
-        expect(spy).toHaveBeenCalledWith('/philosophy/cptsd');
+        expect(spy).toHaveBeenCalledWith('/writing');
+        expect(spy).toHaveBeenCalledWith('/writing/cptsd');
         expect(spy).toHaveBeenCalledTimes(2);
     });
 
     it('also revalidates the previous slug on a rename', () => {
         const spy = vi.fn();
         revalidateArticlePaths(spy, 'new', 'old');
-        expect(spy).toHaveBeenCalledWith('/philosophy/new');
-        expect(spy).toHaveBeenCalledWith('/philosophy/old');
+        expect(spy).toHaveBeenCalledWith('/writing/new');
+        expect(spy).toHaveBeenCalledWith('/writing/old');
     });
 
     it('does not double-revalidate when the slug is unchanged', () => {

--- a/src/lib/__tests__/rss.test.ts
+++ b/src/lib/__tests__/rss.test.ts
@@ -4,12 +4,12 @@ import { generateRSS } from '../rss';
 describe('rss generation', () => {
     it('renders an item per entry with a title and link', () => {
         const xml = generateRSS('https://example.com', [
-            { slug: 'philosophy/hello', title: 'Hello' },
-            { slug: 'philosophy/world', title: 'World' },
+            { slug: 'writing/hello', title: 'Hello' },
+            { slug: 'writing/world', title: 'World' },
         ]);
         expect(xml).toContain('<title>Hello</title>');
         expect(xml).toContain(
-            '<link>https://example.com/philosophy/hello</link>',
+            '<link>https://example.com/writing/hello</link>',
         );
         expect(xml).toContain('<title>World</title>');
     });

--- a/src/lib/admin-articles.ts
+++ b/src/lib/admin-articles.ts
@@ -18,7 +18,7 @@ export function isSlugConflictError(e: unknown): boolean {
 }
 
 /**
- * Revalidate the public philosophy paths affected by an article mutation.
+ * Revalidate the public writing paths affected by an article mutation.
  *
  * Takes `revalidatePath` as a parameter so this stays free of the
  * `next/cache` import (which can only run inside the server runtime), making it
@@ -31,9 +31,9 @@ export function revalidateArticlePaths(
     slug: string,
     previousSlug?: string,
 ): void {
-    revalidatePath('/philosophy');
-    revalidatePath(`/philosophy/${slug}`);
+    revalidatePath('/writing');
+    revalidatePath(`/writing/${slug}`);
     if (previousSlug && previousSlug !== slug) {
-        revalidatePath(`/philosophy/${previousSlug}`);
+        revalidatePath(`/writing/${previousSlug}`);
     }
 }

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -1,10 +1,10 @@
 /**
  * Build an RSS 2.0 feed XML string from a list of items.
  *
- * Items are expected to be already-public (the philosophy feed sources
+ * Items are expected to be already-public (the writing feed sources
  * `published` articles from the MCP Articles API, so there are no private
  * entries to filter). Each item provides the full link path relative to the
- * site root via `slug` (e.g. `philosophy/cptsd`).
+ * site root via `slug` (e.g. `writing/cptsd`).
  */
 export function generateRSS(
     baseUrl: string,

--- a/src/lib/services/__tests__/articles.test.ts
+++ b/src/lib/services/__tests__/articles.test.ts
@@ -18,6 +18,7 @@ vi.mock('@bryandebaun/mcp-client', async (importOriginal) => {
 import {
     getArticleBySlug,
     listPublishedArticles,
+    listRecentPublishedArticles,
 } from '@/lib/services/articles';
 
 const published = {
@@ -63,6 +64,71 @@ describe('listPublishedArticles', () => {
         listArticles.mockResolvedValue({ data: {} });
         const result = await listPublishedArticles();
         expect(result).toEqual([]);
+    });
+});
+
+describe('listRecentPublishedArticles', () => {
+    const make = (slug: string, publishedAt: string | null) => ({
+        ...published,
+        slug,
+        title: slug,
+        publishedAt,
+    });
+
+    it('sorts newest-first', async () => {
+        listArticles.mockResolvedValue({
+            data: {
+                articles: [
+                    make('old', '2024-01-01T00:00:00.000Z'),
+                    make('new', '2026-01-01T00:00:00.000Z'),
+                    make('mid', '2025-01-01T00:00:00.000Z'),
+                ],
+                total: 3,
+            },
+        });
+        const result = await listRecentPublishedArticles();
+        expect(result.map((a) => a.slug)).toEqual(['new', 'mid', 'old']);
+    });
+
+    it('caps the result at the limit (default 5)', async () => {
+        listArticles.mockResolvedValue({
+            data: {
+                articles: Array.from({ length: 8 }, (_, i) =>
+                    make(`a${i}`, `2026-01-0${i + 1}T00:00:00.000Z`),
+                ),
+                total: 8,
+            },
+        });
+        const result = await listRecentPublishedArticles();
+        expect(result).toHaveLength(5);
+    });
+
+    it('returns all when fewer than the limit', async () => {
+        listArticles.mockResolvedValue({
+            data: {
+                articles: [
+                    make('a', '2026-01-01T00:00:00.000Z'),
+                    make('b', '2026-01-02T00:00:00.000Z'),
+                ],
+                total: 2,
+            },
+        });
+        const result = await listRecentPublishedArticles();
+        expect(result).toHaveLength(2);
+    });
+
+    it('sorts articles without publishedAt last', async () => {
+        listArticles.mockResolvedValue({
+            data: {
+                articles: [
+                    make('no-date', null),
+                    make('dated', '2026-01-01T00:00:00.000Z'),
+                ],
+                total: 2,
+            },
+        });
+        const result = await listRecentPublishedArticles();
+        expect(result.map((a) => a.slug)).toEqual(['dated', 'no-date']);
     });
 });
 

--- a/src/lib/services/articles.ts
+++ b/src/lib/services/articles.ts
@@ -38,6 +38,30 @@ export async function listPublishedArticles(): Promise<Article[]> {
 }
 
 /**
+ * List the most-recent published articles, newest first.
+ *
+ * Sorts {@link listPublishedArticles} by `publishedAt` descending; articles
+ * without a `publishedAt` are treated as oldest and sorted last. Returns at
+ * most `limit` articles (default 5). Pure aside from the underlying fetch.
+ */
+export async function listRecentPublishedArticles(
+    limit = 5,
+): Promise<Article[]> {
+    const articles = await listPublishedArticles();
+    const sorted = [...articles].sort((a, b) => {
+        const aTime = a.publishedAt ? Date.parse(a.publishedAt) : Number.NaN;
+        const bTime = b.publishedAt ? Date.parse(b.publishedAt) : Number.NaN;
+        const aValid = !Number.isNaN(aTime);
+        const bValid = !Number.isNaN(bTime);
+        if (aValid && bValid) return bTime - aTime;
+        if (aValid) return -1;
+        if (bValid) return 1;
+        return 0;
+    });
+    return sorted.slice(0, limit);
+}
+
+/**
  * Fetch a single published article by slug. Returns `null` when the article is
  * missing, not published, or the API is unreachable — callers should render a
  * not-found state in that case.


### PR DESCRIPTION
## What

Restructures the articles section and the top navigation.

### Section rename: `/philosophy` → `/writing`
- Route folder renamed (history preserved); all path references updated — list + detail pages, sitemap, RSS feed, ISR revalidation, the editor's "Lives at" hint.
- **Permanent (308) redirects** `/philosophy → /writing` and `/philosophy/:slug* → /writing/:slug*`, so published/indexed URLs (e.g. `/philosophy/cptsd`) keep working.
- Visible "Thoughts & Philosophy" wording is intentionally **unchanged** (deliberate branding choice) — only paths moved.

### Navigation
- **Removed** Contact and Resume from the navbar; **added** Media and Writings (desktop + mobile menus). Final order: About · Projects · Media · Writings.
- The Contact and Resume **links now live on the About page** (their pages are untouched).

### Reusable `Card` + writing list
- Extracted a generic, presentational **`Card`** from `RepoCard` (RepoCard now delegates to it; the Projects page renders identically).
- `/writing` lists the **5 most-recent published articles, newest-first**, as cards showing **Title + Summary** (plus date and tag chips).

### Fix
- Card links no longer underline their text on hover/focus. Root cause: under Tailwind v4 cascade layers, the unlayered global `a:hover` rule beat the layered `no-underline` utility. Fixed at the root by making `.no-underline` anchors authoritative (un-underlined at rest/hover/focus).

## Server / infra

None. Pure frontend; the MCP server and DB are untouched.

## Tests

Card (internal/external link, chips cap), `listRecentPublishedArticles` (sort + limit), updated writing-page/sitemap/RSS/revalidate expectations, redirect-config assertion. Full suite green (299).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
