### PR TITLE
fix: theme-swap themed diagrams + modernize markdown tables

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -114,7 +114,7 @@ img {
   height: auto;
   display: block;
 }
-
+ 
 /* Themed article diagrams render BOTH a light and a dark <img> and swap by
    theme. The swap MUST live here (unlayered, class specificity) rather than via
    Tailwind `hidden`/`dark:*` utilities: those are layered, and under Tailwind v4
@@ -131,6 +131,59 @@ img.themed-img-dark {
 
 .dark img.themed-img-dark {
   display: block;
+}
+
+/* Markdown (GFM) tables inside article bodies. The admin/media data grids use
+   the dedicated <Table> component; this styles prose-authored tables only.
+   Written as unlayered, class-specificity rules so they win over Tailwind's
+   layered prose table defaults (and the bare browser defaults that were
+   leaving cells with no padding). A `table` wrapper in ArticleBody adds
+   horizontal scroll for wide tables. */
+.prose table {
+  width: auto;
+  max-width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.prose thead th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--color-norwegian-800);
+  background: var(--color-norwegian-50);
+  padding: 0.5rem 0.9rem;
+  border-bottom: 2px solid var(--color-norwegian-300);
+  white-space: nowrap;
+}
+
+.prose tbody td {
+  padding: 0.5rem 0.9rem;
+  border-bottom: 1px solid var(--color-norwegian-200);
+  vertical-align: top;
+}
+
+.prose tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.prose tbody tr:hover {
+  background: color-mix(in srgb, var(--color-norwegian-100) 55%, transparent);
+}
+
+.dark .prose thead th {
+  color: var(--color-norwegian-100);
+  background: rgba(255, 255, 255, 0.04);
+  border-bottom-color: var(--color-norwegian-300-dark);
+}
+
+.dark .prose tbody td {
+  border-bottom-color: var(--color-norwegian-200-dark);
+}
+
+.dark .prose tbody tr:hover {
+  background: rgba(255, 255, 255, 0.05);
 }
 
 /* Utility: allow a child container to full-bleed the viewport while

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -143,7 +143,8 @@ img.themed-img-dark {
   width: auto;
   max-width: 100%;
   border-collapse: collapse;
-  margin: 1.5rem 0;
+  /* `auto` side margins center the content-width table in its column. */
+  margin: 1.5rem auto;
   font-size: 0.95rem;
   line-height: 1.45;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -115,6 +115,24 @@ img {
   display: block;
 }
 
+/* Themed article diagrams render BOTH a light and a dark <img> and swap by
+   theme. The swap MUST live here (unlayered, class specificity) rather than via
+   Tailwind `hidden`/`dark:*` utilities: those are layered, and under Tailwind v4
+   cascade layers the unlayered `img { display: block }` rule above outranks
+   them — which would otherwise leave both variants visible. The light variant
+   keeps the global `display: block`; the dark variant is hidden until `.dark`. */
+img.themed-img-dark {
+  display: none;
+}
+
+.dark img.themed-img-light {
+  display: none;
+}
+
+.dark img.themed-img-dark {
+  display: block;
+}
+
 /* Utility: allow a child container to full-bleed the viewport while
    preserving site gutters. Use on pages that should use the entire width.
    Example: <div class="prose site-bleed max-w-none">...</div> */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -164,6 +164,14 @@ img.themed-img-dark {
   vertical-align: top;
 }
 
+/* Default alignment: the first column reads as row labels (left); value columns
+   are centered. Authors can still override per column with GFM alignment
+   (`:---:`), whose inline `text-align` wins over this rule. */
+.prose thead th:not(:first-child),
+.prose tbody td:not(:first-child) {
+  text-align: center;
+}
+
 .prose tbody tr:last-child td {
   border-bottom: 0;
 }

--- a/src/components/ArticleBody.tsx
+++ b/src/components/ArticleBody.tsx
@@ -136,6 +136,22 @@ function MarkdownImage({
 }
 
 /**
+ * Wrap GFM tables in a horizontally scrollable container so a wide table never
+ * overflows the page on small screens. The table itself is styled in
+ * `globals.css` (`.prose table`).
+ */
+function MarkdownTable({
+    node: _node,
+    ...props
+}: ComponentPropsWithoutRef<'table'> & { node?: unknown }) {
+    return (
+        <div className="overflow-x-auto">
+            <table {...props} />
+        </div>
+    );
+}
+
+/**
  * Render a DB-sourced Markdown article body as React.
  *
  * Security: bodies come from the database, so we render via `react-markdown`
@@ -150,7 +166,11 @@ export default function ArticleBody({ body }: { body: string }) {
             <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
                 rehypePlugins={[rehypeSanitize]}
-                components={{ a: MarkdownAnchor, img: MarkdownImage }}
+                components={{
+                    a: MarkdownAnchor,
+                    img: MarkdownImage,
+                    table: MarkdownTable,
+                }}
             >
                 {content}
             </ReactMarkdown>

--- a/src/components/ArticleBody.tsx
+++ b/src/components/ArticleBody.tsx
@@ -109,7 +109,7 @@ function MarkdownImage({
                     src={themed.light}
                     alt={alt ?? ''}
                     title={title}
-                    className="mx-auto block h-auto max-w-full dark:hidden"
+                    className="themed-img-light mx-auto h-auto max-w-full"
                     {...rest}
                 />
                 {/* eslint-disable-next-line @next/next/no-img-element -- see above */}
@@ -117,7 +117,7 @@ function MarkdownImage({
                     src={themed.dark}
                     alt={alt ?? ''}
                     title={title}
-                    className="mx-auto hidden h-auto max-w-full dark:block"
+                    className="themed-img-dark mx-auto h-auto max-w-full"
                     {...rest}
                 />
             </>

--- a/src/components/__tests__/ArticleBody.test.tsx
+++ b/src/components/__tests__/ArticleBody.test.tsx
@@ -72,9 +72,13 @@ describe('ArticleBody rendering', () => {
         expect(container.querySelector('script')).toBeNull();
     });
 
-    it('renders GFM tables via remark-gfm', () => {
+    it('renders GFM tables via remark-gfm, wrapped for horizontal scroll', () => {
         render(<ArticleBody body={'| a | b |\n| - | - |\n| 1 | 2 |'} />);
-        expect(screen.getByRole('table')).toBeInTheDocument();
+        const table = screen.getByRole('table');
+        expect(table).toBeInTheDocument();
+        // Wide tables must not overflow the page — the table is wrapped in a
+        // horizontally scrollable container.
+        expect(table.parentElement?.className).toContain('overflow-x-auto');
     });
 
     it('pairs a themed /articles SVG with its _dark sibling and CSS-swaps', () => {

--- a/src/components/__tests__/ArticleBody.test.tsx
+++ b/src/components/__tests__/ArticleBody.test.tsx
@@ -89,7 +89,7 @@ describe('ArticleBody rendering', () => {
         // Light variant: real alt, shown in light mode / hidden in dark.
         expect(light).toHaveAttribute('src', '/articles/xe_all_committed.svg');
         expect(light).toHaveAttribute('alt', 'All committed');
-        expect(light.className).toContain('dark:hidden');
+        expect(light.className).toContain('themed-img-light');
         // Dark variant: derived _dark src, same alt (display:none de-dupes the
         // a11y tree, so the alt is announced in dark mode too).
         expect(dark).toHaveAttribute(
@@ -97,7 +97,7 @@ describe('ArticleBody rendering', () => {
             '/articles/xe_all_committed_dark.svg',
         );
         expect(dark).toHaveAttribute('alt', 'All committed');
-        expect(dark.className).toContain('dark:block');
+        expect(dark.className).toContain('themed-img-dark');
     });
 
     it('does not pair non-/articles images (single img, no _dark swap)', () => {
@@ -140,8 +140,8 @@ describe('ArticleBody rendering', () => {
         );
         expect(light).toHaveAttribute('alt', 'diagram');
         expect(dark).toHaveAttribute('alt', 'diagram');
-        expect(light.className).toContain('dark:hidden');
-        expect(dark.className).toContain('dark:block');
+        expect(light.className).toContain('themed-img-light');
+        expect(dark.className).toContain('themed-img-dark');
         for (const img of imgs) {
             expect(img.getAttribute('src')).not.toContain('#themed');
         }


### PR DESCRIPTION
Two related article-rendering fixes that touch the same files (`globals.css`, `ArticleBody.tsx`), so they're bundled.

## 1. Theme-swap themed diagrams (only show the matching variant)

A themed diagram (a `…svg#themed` upload, or a committed pair under the diagrams folder) rendered **both** the light and dark variants stacked instead of swapping.

**Root cause:** the swap used Tailwind `block` / `hidden` / `dark:*` utilities, which are **layered**. The global `img { display: block }` rule is **unlayered**, and under Tailwind v4 cascade layers an unlayered rule outranks layered utilities regardless of specificity — so both `<img>`s stayed `display: block`.

**Fix:** express the swap as unlayered, class-specificity CSS (`img.themed-img-dark`, `.dark img.themed-img-light`, `.dark img.themed-img-dark`); `MarkdownImage` tags the variants with those classes. Light mode shows the light variant, dark mode shows the dark. Covers uploaded (`#themed`) and committed pairs.

## 2. Modern styling for markdown tables

Prose-authored GFM tables rendered nearly unstyled (no cell padding or separators — e.g. "Dribbles completed3").

**Fix:** unlayered, theme-aware `.prose table` styles — header rule + subtle tint, row separators, comfortable padding, hover highlight — plus a `table` wrapper in `ArticleBody` that adds horizontal scroll so wide tables don't overflow on mobile. Scoped to `.prose`, so the admin/media `<Table>` component is unaffected.

## Tests

Updated `ArticleBody` pairing tests for the new swap classes; added a scroll-wrapper assertion to the table test. Full suite green (313). The `themed-img-*` swap rules are verified present in the compiled CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
