### PR TITLE
feat: auth modernization — social login (GitHub + Google) + passkeys (ADR 0006)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Open [http://localhost:3000](http://localhost:3000).
 
 Note: the `build` script enforces `NODE_ENV=production` to ensure consistent production builds even when a system-level `NODE_ENV` differs. Use `pnpm run dev` for development runs.
 
+### Authentication feature flags
+
+- `NEXT_PUBLIC_ENABLE_PASSKEYS` — set to `true` to enable the **experimental** passkey (WebAuthn) UI: a "Sign in with a passkey" button on `/login` and `/register`, plus passkey management (add / list / rename / delete) on `/account`. When unset (the default, including CI), all passkey UI is hidden and email/password, magic-link, and social login are unaffected. Passkeys are strictly additive and never a sole credential (see `docs/adr/0006-auth-modernization-social-passkeys.md`). The passkey ceremony only works on the production origin (`https://bryandebaun.dev`), not on `localhost` or preview deploys.
+
 ## Troubleshooting
 
 ### Missing devDependencies when NODE_ENV is set to `production`

--- a/docs/adr/0006-auth-modernization-social-passkeys.md
+++ b/docs/adr/0006-auth-modernization-social-passkeys.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-29
 
-Status: Proposed
+Status: Accepted (2026-06-29)
 
 ## Context
 
@@ -87,14 +87,22 @@ the email/password e2e suite**. Everything else is right-sized down.
 Adopt a **two-phase, additive** modernization that keeps every existing method
 working:
 
-- **Phase 1 — Social login (GitHub + Google) via Supabase OAuth.** Mature, GA,
-  no client bump. Add `signInWithOAuth` buttons on `/login` (and `/register`)
-  that redirect through the **existing** `/auth/callback`. **Recommended and
-  low-risk.**
-- **Phase 2 — Passkeys via Supabase-native experimental API**, **strictly
-  additive and behind the existing fallbacks**, gated by an env flag, and
-  shipped as its own `supabase-js ≥ 2.105.0` bump. Primarily to give the admin a
-  phishing-resistant factor — **never** the only way in.
+- **One combined effort, not phased across releases.** Social login and
+  passkeys ship together on a single feature branch (`feat/auth-modernization`)
+  to get maximum value from one setup pass. The **env flag** on passkeys is the
+  risk container: if the experimental API misbehaves mid-build, social login
+  still lands and passkeys toggle off — no separate later release needed.
+- **Social login (GitHub + Google) via Supabase OAuth.** Mature, GA, no client
+  bump. Add `signInWithOAuth` buttons on **both `/login` and `/register`**,
+  redirecting through the **existing** `/auth/callback`.
+- **Passkeys via Supabase-native experimental API** — **strictly additive and
+  behind the existing fallbacks**, gated by `NEXT_PUBLIC_ENABLE_PASSKEYS`, and
+  shipped with its own `supabase-js ≥ 2.105.0` bump (a discrete, reviewed commit
+  on the branch). **Offered to all users**, not admin-only — the code is
+  identical regardless of role, and the password/magic-link floor means a lost
+  passkey is never a lockout for anyone. Enrollment happens **post-sign-in**
+  (WebAuthn requires a session); passkey *sign-in* (`signInWithPasskey`) appears
+  on `/login` and `/register`.
 - **Keep email/password + magic-link permanently** as universal fallbacks and as
   the programmatic path for e2e. Nothing is removed.
 - **Identity-linking policy:** rely on Supabase's **automatic linking on
@@ -138,10 +146,9 @@ churns the API painfully, fall back to Option C (defer) — not B.
   the existing email/password identity and on both Google and GitHub (GitHub
   must have that address as a **verified** email). Signing in via any of them
   resolves to the **one** existing user — so `app_metadata.role: admin` is
-  preserved and admin access "just works" across methods. **Action item:**
-  confirm `brn.dbn@gmail.com` is a verified email on the GitHub account before
-  relying on GitHub linking; otherwise GitHub returns a different/again-verified
-  identity.
+  preserved and admin access "just works" across methods. **Confirmed
+  (2026-06-29):** `brn.dbn@gmail.com` is a verified email on the GitHub account,
+  so GitHub auto-links cleanly to the existing admin user.
 - **Security note:** auto-linking is only safe because Supabase refuses to link
   **unverified** emails (pre-account-takeover protection). The risk to avoid is a
   provider that returns an **unverified** email — Supabase won't auto-link it,
@@ -221,6 +228,11 @@ churns the API painfully, fall back to Option C (defer) — not B.
 
 ## Rollout / Rollback
 
+Both ship on the one `feat/auth-modernization` branch; the "phases" below are the
+**work order within that branch**, not separate releases. Social login is built
+and verified first (it can't fail), then the `supabase-js` bump and passkeys land
+behind the env flag.
+
 ### Phase 1 — Social login (GitHub + Google) — *low risk, do first*
 
 1. **Provider apps:** create a GitHub OAuth App and a Google OAuth client; set
@@ -272,22 +284,25 @@ churns the API painfully, fall back to Option C (defer) — not B.
 
 - [ ] ADR committed to `docs/adr/` capturing drivers/NFRs, per-capability
   options, identity-linking policy, anti-lockout strategy, CI/e2e impact,
-  phased rollout, and consequences.
-- [ ] Phase-1 (social login) implementation issue created and linked.
-- [ ] Phase-2 (passkeys) follow-up issue created and linked, noting the
-  `supabase-js ≥ 2.105.0` bump as its own step and the experimental risk.
+  rollout, and consequences.
+- [ ] Tracking issue created for the combined `feat/auth-modernization` effort,
+  with task groups for social login and passkeys (the latter noting the
+  `supabase-js ≥ 2.105.0` bump as its own commit and the experimental risk).
+- [ ] An e2e guard test remains that fails if email/password login ever breaks.
 
-## Open questions (for Bryan)
+## Resolved decisions (2026-06-29)
 
-1. **GitHub email:** is `brn.dbn@gmail.com` a **verified** email on the GitHub
-   account (required for clean auto-linking to the existing admin)?
-2. **Passkey scope:** admin-only for now, or offered to all users? (Recommend
-   admin-only initially — fewer support paths, the value is admin phishing
-   resistance.)
-3. **Phase-2 timing:** ship passkeys soon after Phase 1, or hold until the
-   Supabase experimental API stabilizes / graduates to GA?
-4. **`/register` exposure:** put social buttons on `/register` too, or keep
-   registration email/password-only and surface social only on `/login`?
+1. **GitHub email** — `brn.dbn@gmail.com` is **verified** on GitHub, so it
+   auto-links cleanly to the existing admin user. ✓
+2. **Passkey scope** — offered to **all users**, not admin-only. The
+   functionality is identical regardless of role, and the password + magic-link
+   floor means a lost passkey is never a lockout for anyone.
+3. **Timing** — social login and passkeys ship **together in one effort** (one
+   feature branch / setup pass), with the passkey **env flag** as the risk
+   container rather than a separate later phase.
+4. **`/register`** — social buttons appear on **both `/login` and `/register`**.
+   Passkey *enrollment* still happens post-sign-in (WebAuthn requires a confirmed
+   session); passkey *sign-in* can appear on both pages.
 
 ## Related
 

--- a/docs/adr/0006-auth-modernization-social-passkeys.md
+++ b/docs/adr/0006-auth-modernization-social-passkeys.md
@@ -1,0 +1,300 @@
+# ADR 0006 — Auth modernization: social login (GitHub + Google) & passkeys
+
+Date: 2026-06-29
+
+Status: Proposed
+
+## Context
+
+The site already has a working Supabase Auth surface (see ADR 0003 for the key
+model and the `app_metadata.role === 'admin'` authorization rule). Today users
+can authenticate with **email/password** (`signInWithPassword`) and
+**magic-link** (`signInWithOtp`), and a **PKCE `/auth/callback`** route
+(`src/app/auth/callback/route.ts`) already calls `exchangeCodeForSession`. The
+auth surface lives under `src/app/login`, `src/app/register`, and
+`src/app/api/auth/{login,register,magic-link,me,reset-password,update-password,logout}`,
+with clients in `src/lib/supabase/{server,client,admin}.ts`.
+
+Two modern sign-in methods are worth adding:
+
+1. **Social login (GitHub + Google)** — lower-friction sign-in, no password to
+   manage, and a natural fit since the real admin (`brn.dbn@gmail.com`) has both
+   a Google and a GitHub identity.
+2. **Passkeys / WebAuthn (biometric)** — phishing-resistant, passwordless
+   authentication bound to the device. The strongest available protection for
+   the single privileged admin account.
+
+This is a personal site with **one real admin** and a learning goal, not an
+enterprise SSO rollout. The bar is: make sign-in nicer and meaningfully harder
+to phish **without ever risking lockout of the admin** and **without breaking
+the email/password e2e suite**. Everything else is right-sized down.
+
+### Current stack (verified against the code, 2026-06-29)
+
+- Next.js 16 App Router, React 19, TS strict.
+- `@supabase/ssr` `^0.10.2`, `@supabase/supabase-js` **`^2.103.0`**.
+- Supabase project ref `nanodcvcpklffksxofbm`; modern publishable/secret keys
+  (ADR 0003).
+- Browser client: `createBrowserClient(NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY)`.
+- Admin auth: `app_metadata.role === 'admin'` enforced in `src/lib/auth-guard.ts`
+  (`requireAdmin` / `requireAdminPage`) — **never** `user_metadata`.
+- e2e/integration: Playwright suite logs in dedicated `e2e-admin@` / `e2e-user@`
+  users with **email/password** (creds in gitignored `.env.local`).
+
+### Verified facts (Supabase docs, re-confirmed 2026-06-29)
+
+- **Social OAuth** is GA and first-class: `signInWithOAuth({ provider, options: { redirectTo } })`
+  returns a provider URL; the redirect lands on the existing `/auth/callback`
+  PKCE route and reuses `exchangeCodeForSession`. Works on the installed
+  `supabase-js` 2.103.0. **No client bump required.**
+- **Automatic identity linking**: when a user signs in via a new provider with
+  an email that matches an existing user, Supabase **auto-links** the identity —
+  **but only when the email is verified** on both sides. Linking to unverified
+  emails is refused (pre-account-takeover protection), and unconfirmed
+  identities are removed when a new identity is linked. Emails must be unique.
+  Manual `linkIdentity()` / `unlinkIdentity()` exist but require opt-in
+  (`GOTRUE_SECURITY_MANUAL_LINKING_ENABLED`); unlinking requires ≥2 identities.
+- **Passkeys / WebAuthn** are **EXPERIMENTAL** ("The API may change without
+  notice"):
+  - Requires `@supabase/supabase-js` **≥ 2.105.0** (a bump from 2.103.0) and an
+    explicit opt-in: `auth: { experimental: { passkey: true } }`.
+  - Client methods: `registerPasskey()` (enroll, must be an authenticated,
+    confirmed, non-anonymous, non-SSO user) and `signInWithPasskey()`
+    (passwordless via **discoverable credentials** — no email needed at
+    sign-in). A lower-level `auth.passkey.*` two-step API also exists.
+  - Dashboard config needs a **Relying Party (RP) ID** = the **bare domain**
+    (`bryandebaun.dev`, no scheme/port), a display name, and up to **5 HTTPS
+    origins** that match or are subdomains of the RP ID. `localhost` is allowed
+    for dev.
+  - **Changing the RP ID invalidates every enrolled passkey** — pick it once and
+    keep it stable.
+  - Anonymous and SSO users cannot enroll.
+
+## Decision drivers / NFRs
+
+| Driver | Target |
+| --- | --- |
+| **No lockout / recovery** | The admin (`brn.dbn@gmail.com`) must **always** have ≥2 independent ways in; no single method (passkey, one provider) can be a single point of failure. This is the hard constraint. |
+| **Phishing resistance** | Add at least one phishing-resistant factor (passkey) for the admin; social OAuth raises the bar over password reuse. |
+| **e2e/CI continuity** | A **programmatic email/password** login path must remain for the Playwright integration suite. Social/passkey cannot be automated cheaply. |
+| **Admin security** | Defense-in-depth for the one account that can mutate content; authorization stays on `app_metadata.role`. |
+| **Maintenance burden** | Prefer "with the grain" (stay on Supabase) over a parallel auth stack. |
+| **Experimental-API risk** | Passkeys may change without notice → must be additive, behind fallbacks, and trivially disable-able. |
+| **Cost** | $0. Supabase OAuth and passkeys add no line-item cost; provider apps (GitHub/Google) are free. |
+
+## Decision
+
+Adopt a **two-phase, additive** modernization that keeps every existing method
+working:
+
+- **Phase 1 — Social login (GitHub + Google) via Supabase OAuth.** Mature, GA,
+  no client bump. Add `signInWithOAuth` buttons on `/login` (and `/register`)
+  that redirect through the **existing** `/auth/callback`. **Recommended and
+  low-risk.**
+- **Phase 2 — Passkeys via Supabase-native experimental API**, **strictly
+  additive and behind the existing fallbacks**, gated by an env flag, and
+  shipped as its own `supabase-js ≥ 2.105.0` bump. Primarily to give the admin a
+  phishing-resistant factor — **never** the only way in.
+- **Keep email/password + magic-link permanently** as universal fallbacks and as
+  the programmatic path for e2e. Nothing is removed.
+- **Identity-linking policy:** rely on Supabase's **automatic linking on
+  verified email** and **keep manual linking disabled**. Same verified email via
+  Google/GitHub/password resolves to one account (see policy below).
+- **RP ID = `bryandebaun.dev`**, chosen once and frozen. Origins:
+  `https://bryandebaun.dev` (prod) and `http://localhost:3000` (dev).
+
+### Options considered — Social login
+
+| Option | Pros | Cons | Verdict |
+| --- | --- | --- | --- |
+| **A. Supabase OAuth** (recommended) | GA; reuses existing PKCE `/auth/callback`; no client bump; sessions/`app_metadata` model unchanged; auto identity-linking on verified email | Provider apps + redirect allowlists to configure in two consoles | **Chosen** |
+| B. External auth layer (Auth.js / NextAuth) | Provider-rich; framework-popular | Introduces a **second** session/identity system parallel to Supabase; the entire authorization model (`app_metadata.role`, `auth-guard.ts`, MCP JWT in ADR 0004) assumes a Supabase session; large rewrite for zero net benefit on a single-admin site | Rejected — runs against the "with the grain" principle |
+| C. Hand-rolled OAuth | Full control | Reinvents a solved, security-sensitive flow | Rejected |
+
+Staying on Supabase is correct because the **incumbent** authorization model,
+the MCP API client's Supabase-JWT admin auth (ADR 0004), and `auth-guard.ts` are
+all built on a Supabase session. OAuth here is purely additive: a new way to
+obtain that **same** session.
+
+### Options considered — Passkeys
+
+| Option | Pros | Cons | Verdict |
+| --- | --- | --- | --- |
+| **A. Supabase-native experimental** (recommended, Phase 2) | Integrates with the existing Supabase session & `app_metadata`; discoverable credentials; admin API; minimal code | **Experimental** (may change without notice); needs `supabase-js ≥ 2.105.0` + opt-in flag; RP-ID fragility | **Chosen, behind fallbacks + env flag** |
+| B. Self-managed WebAuthn (SimpleWebAuthn) + custom credential storage | Stable, fully controlled API; not tied to Supabase's experimental track | Must build registration/auth ceremonies, challenge storage, and **bind credentials to the Supabase session myself**; materially more code and a new security-critical surface to maintain for one user | Rejected for now — disproportionate effort |
+| C. Defer passkeys | Zero risk; no churn | Leaves the admin without a phishing-resistant factor | Rejected — but acceptable as a Phase-2 hold if the experimental API proves unstable |
+
+Rationale: for a single-admin learning project, the experimental Supabase path
+gives 80% of the value for ~10% of the effort of B. The experimental risk is
+**contained** because passkeys are never the only factor and the feature can be
+disabled by an env flag without touching the OAuth/password paths. If Supabase
+churns the API painfully, fall back to Option C (defer) — not B.
+
+### Identity-linking policy
+
+- **Keep automatic linking on; keep manual linking off** (do **not** set
+  `GOTRUE_SECURITY_MANUAL_LINKING_ENABLED`).
+- Consequence for the admin: `brn.dbn@gmail.com` is the same verified email on
+  the existing email/password identity and on both Google and GitHub (GitHub
+  must have that address as a **verified** email). Signing in via any of them
+  resolves to the **one** existing user — so `app_metadata.role: admin` is
+  preserved and admin access "just works" across methods. **Action item:**
+  confirm `brn.dbn@gmail.com` is a verified email on the GitHub account before
+  relying on GitHub linking; otherwise GitHub returns a different/again-verified
+  identity.
+- **Security note:** auto-linking is only safe because Supabase refuses to link
+  **unverified** emails (pre-account-takeover protection). The risk to avoid is a
+  provider that returns an **unverified** email — Supabase won't auto-link it,
+  which is the safe outcome (a separate, non-admin user is created rather than a
+  takeover). We accept Supabase's default behavior here rather than building
+  custom linking logic.
+- **Out of scope:** user-facing "connect your GitHub/Google" account-management
+  UI. Not needed for one admin; revisit only if multi-identity self-service is
+  ever wanted.
+
+### Anti-lockout / fallback strategy (the hard constraint)
+
+- **Email/password stays forever.** It is the recovery floor and the e2e path.
+- **Magic-link stays forever.** Email-based passwordless recovery if a password
+  is forgotten.
+- **Passkeys are additive only.** The admin enrolls a passkey **in addition to**
+  password + at least one social identity — never as a sole credential.
+- **Admin-specific protection for `brn.dbn@gmail.com`:**
+  - Maintain **≥2 independent factors at all times**: (password + magic-link via
+    email) is already two; social and passkey are bonuses.
+  - **Passkey lost-device recovery:** because email/password and magic-link
+    remain, a lost passkey is **not** a lockout — sign in by password/magic-link
+    and re-enroll a new passkey. Enroll passkeys on **≥2 devices** where
+    practical (e.g. phone + laptop, or rely on iCloud/Google passkey sync).
+  - **RP-ID safety:** never change the RP ID after first enrollment (it would
+    silently invalidate every passkey). If it ever must change, treat it as a
+    full re-enrollment event with password/magic-link as the bridge.
+  - **Service-role break-glass:** the existing Supabase **secret key** (ADR 0003)
+    can reset the admin password or `app_metadata` out-of-band via `auth.admin.*`
+    — the ultimate recovery lever, already in place.
+- **Net effect:** no method we add can cause lockout, because the two
+  email-bound methods that exist today are never removed.
+
+### CI / e2e impact
+
+- The Playwright integration suite authenticates `e2e-admin@` / `e2e-user@` via
+  **email/password** through `/api/auth/login`. **That path is untouched** by
+  this ADR — email/password sign-in is explicitly retained, so the suite keeps
+  working with no changes.
+- **Do not** attempt to automate OAuth or passkey ceremonies in CI (real
+  provider consent screens / platform authenticators can't be driven reliably
+  and cheaply). Coverage for the new flows is:
+  - Social: a lightweight test asserting the OAuth button calls
+    `signInWithOAuth` with the right provider + `redirectTo` (mock the client),
+    plus a manual smoke check against the provider once per setup.
+  - Passkey: unit-level assertions that the UI calls `registerPasskey` /
+    `signInWithPasskey` behind the env flag; no real WebAuthn ceremony in CI.
+- **Guard:** keep at least one e2e test that fails if email/password login ever
+  stops working, so a future refactor can't quietly remove the e2e/recovery path.
+
+## Consequences
+
+- **Positive**
+  - Lower-friction sign-in (one-click GitHub/Google) and a phishing-resistant
+    option (passkey) for the admin — better security posture for the one account
+    that matters.
+  - Stays entirely "with the grain": same Supabase session, same
+    `app_metadata.role` authorization, same `/auth/callback`, same MCP admin auth
+    (ADR 0004). No second auth stack.
+  - $0 incremental cost.
+  - Additive-only: nothing existing is removed; the e2e/recovery path is
+    preserved by design.
+  - A genuine **learning** surface: OAuth/PKCE wiring and WebAuthn/passkeys.
+- **Negative**
+  - **Passkeys ride an experimental API** that may change without notice →
+    ongoing maintenance attention; mitigated by env-flag gating and fallbacks.
+  - A **`supabase-js` bump to ≥ 2.105.0** is required for Phase 2 (its own
+    reviewed step; re-verify no breaking changes in `@supabase/ssr` interop).
+  - More configuration surface: provider apps (GitHub/Google), redirect-URL
+    allowlists in **both** Supabase and each provider console, and dev-vs-prod
+    origins/RP ID to keep straight.
+  - **RP-ID fragility:** an accidental RP-ID change invalidates all passkeys
+    (mitigated by freezing it and documenting it loudly).
+  - Auto identity-linking depends on provider-verified emails; a misconfigured
+    GitHub email could create a separate non-admin user (safe, but confusing) —
+    mitigated by the verify-GitHub-email action item.
+
+## Rollout / Rollback
+
+### Phase 1 — Social login (GitHub + Google) — *low risk, do first*
+
+1. **Provider apps:** create a GitHub OAuth App and a Google OAuth client; set
+   each provider's callback to the Supabase auth callback
+   (`https://<project-ref>.supabase.co/auth/v1/callback`).
+2. **Supabase dashboard:** enable GitHub + Google providers; paste client
+   IDs/secrets; add **Redirect URL allowlist** entries for
+   `https://bryandebaun.dev/auth/callback` and
+   `http://localhost:3000/auth/callback`.
+3. **Code:** add "Continue with GitHub / Google" buttons on `/login` (and
+   `/register`) calling
+   `supabase.auth.signInWithOAuth({ provider, options: { redirectTo: \`${SITE_URL}/auth/callback\` } })`.
+   No callback-route change needed (it already does `exchangeCodeForSession`).
+4. **Verify:** `brn.dbn@gmail.com` via Google and via GitHub both resolve to the
+   existing admin user (auto-link on verified email) and retain
+   `app_metadata.role: admin`.
+5. **Rollback:** disable the providers in the Supabase dashboard and hide the
+   buttons — password/magic-link unaffected. Pure config + UI revert.
+
+### Phase 2 — Passkeys — *experimental, do after Phase 1 is stable*
+
+1. **Bump** `@supabase/supabase-js` to **≥ 2.105.0** as a standalone change;
+   verify build + e2e + `@supabase/ssr` interop. Treat as its own PR.
+2. **Dashboard:** configure RP **ID = `bryandebaun.dev`** (frozen), display name,
+   and origins `https://bryandebaun.dev` + `http://localhost:3000`.
+3. **Client opt-in:** enable `auth: { experimental: { passkey: true } }` on the
+   browser client, gated by an env flag (e.g. `NEXT_PUBLIC_ENABLE_PASSKEYS`) so
+   it can be turned off instantly.
+4. **UI:** add "Enroll a passkey" in an authenticated/account context
+   (`registerPasskey`) and "Sign in with a passkey" on `/login`
+   (`signInWithPasskey`), both shown only when the flag is on and **always
+   alongside** the password/magic-link options.
+5. **Admin enrollment:** enroll passkeys on ≥2 devices (or rely on platform
+   sync), with password/magic-link confirmed working first.
+6. **Rollback:** flip `NEXT_PUBLIC_ENABLE_PASSKEYS` off (UI disappears, fallbacks
+   remain). If the experimental API breaks, defer (Option C) without affecting
+   OAuth/password. **Do not** change the RP ID as part of any rollback.
+
+### Operability notes
+
+- Document the redirect-URL allowlists (Supabase **and** both provider consoles)
+  and the dev-vs-prod origins/RP-ID in the rollout runbook; allowlist drift is
+  the most likely cause of a broken OAuth redirect.
+- Add the verify-`brn.dbn@gmail.com`-on-GitHub action item to Phase-1 acceptance.
+- No new alerting needed at this scale; rely on the existing auth-route debug
+  logging (masked email) and a manual post-deploy smoke check per method.
+
+## Acceptance criteria
+
+- [ ] ADR committed to `docs/adr/` capturing drivers/NFRs, per-capability
+  options, identity-linking policy, anti-lockout strategy, CI/e2e impact,
+  phased rollout, and consequences.
+- [ ] Phase-1 (social login) implementation issue created and linked.
+- [ ] Phase-2 (passkeys) follow-up issue created and linked, noting the
+  `supabase-js ≥ 2.105.0` bump as its own step and the experimental risk.
+
+## Open questions (for Bryan)
+
+1. **GitHub email:** is `brn.dbn@gmail.com` a **verified** email on the GitHub
+   account (required for clean auto-linking to the existing admin)?
+2. **Passkey scope:** admin-only for now, or offered to all users? (Recommend
+   admin-only initially — fewer support paths, the value is admin phishing
+   resistance.)
+3. **Phase-2 timing:** ship passkeys soon after Phase 1, or hold until the
+   Supabase experimental API stabilizes / graduates to GA?
+4. **`/register` exposure:** put social buttons on `/register` too, or keep
+   registration email/password-only and surface social only on `/login`?
+
+## Related
+
+- Builds on **ADR 0003** (Supabase API keys & `app_metadata.role` admin model)
+  and **ADR 0004** (MCP API client — Supabase-JWT admin auth), both of which
+  assume a Supabase session that this ADR keeps as the single identity system.
+- Touches the existing PKCE `/auth/callback` route and the
+  `src/app/api/auth/*` surface.
+
+Author: Bryan DeBaun

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@bryandebaun/mcp-client": "workspace:*",
     "@radix-ui/react-select": "^2.3.1",
     "@supabase/ssr": "^0.10.2",
-    "@supabase/supabase-js": "^2.103.0",
+    "@supabase/supabase-js": "^2.110.0",
     "@tanstack/react-query": "^5.90.20",
     "@tanstack/react-query-devtools": "^5.91.3",
     "@tanstack/react-table": "^8.21.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,10 +16,10 @@ importers:
         version: 2.3.1(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@supabase/ssr':
         specifier: ^0.10.2
-        version: 0.10.2(@supabase/supabase-js@2.103.0)
+        version: 0.10.2(@supabase/supabase-js@2.110.0)
       '@supabase/supabase-js':
-        specifier: ^2.103.0
-        version: 2.103.0
+        specifier: ^2.110.0
+        version: 2.110.0
       '@tanstack/react-query':
         specifier: ^5.90.20
         version: 5.90.20(react@19.2.3)
@@ -1654,37 +1654,37 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@supabase/auth-js@2.103.0':
-    resolution: {integrity: sha512-6zAanO6c+6gpHOlt5Lb9TlBBkJdZiUWkWCJKAxzkywBDcwaHlLJKXnjQGX6GyVCyKRR1e7sTq4re/yRTH6U/9A==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/auth-js@2.110.0':
+    resolution: {integrity: sha512-Mi288WCTp6wxMFCOu/UgzgHEXODjdl2uVTLqK11eanzGZaldU3RyP8Am+ZbNuVzFP+5+iOvppxzv7N5Ym84xTg==}
+    engines: {node: '>=22.0.0'}
 
-  '@supabase/functions-js@2.103.0':
-    resolution: {integrity: sha512-YrneV2NjskUkkmkZ2Jt2n3elBgbWzV4Y1M9MM370z2Zd5ZPFqFbY8KIoPwuNjtAGE9YrpKBxnbZqeF07BiN9Og==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/functions-js@2.110.0':
+    resolution: {integrity: sha512-Fde5wlY8ZZy+9yqrWlQHo8MacSyUBArBEtN2boB4thJQigPnQD/cc61qZN0n3I1L0gwhWtHYwIMnOBKxSvF6Hw==}
+    engines: {node: '>=22.0.0'}
 
-  '@supabase/phoenix@0.4.0':
-    resolution: {integrity: sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==}
+  '@supabase/phoenix@0.4.4':
+    resolution: {integrity: sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==}
 
-  '@supabase/postgrest-js@2.103.0':
-    resolution: {integrity: sha512-rC3sRxYdPZymkp2CZR1MiNQgbOleD01bGsW8VxEKRR5nMkLZ1NgAS1QTQf78Wh30czFyk505ZYr9Od8/mWT2TA==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/postgrest-js@2.110.0':
+    resolution: {integrity: sha512-ZbC1QZL3jcvBUfVKjJbgRM27G4Mg3Zzqdm44m5pJafe1e52Cli793EOnwQucomBAGEUDd03Nzaf7XV3ji/XexQ==}
+    engines: {node: '>=22.0.0'}
 
-  '@supabase/realtime-js@2.103.0':
-    resolution: {integrity: sha512-gcPtXzZ6izyyBVf2of7K3dEt8CScPJn8VcSlQq6oWL9QoE1kqfQl0oFrOMHd5qrcADewxI7OxxosLB8W4XqtIQ==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/realtime-js@2.110.0':
+    resolution: {integrity: sha512-Wn2AWpneZuDFTkp/65tqctvoh+3JvyTjMam8sTMqVWy5BgkU8zAvFwilPYPPPhkINeKF8NAJKP7FclJ2iGCUMw==}
+    engines: {node: '>=22.0.0'}
 
   '@supabase/ssr@0.10.2':
     resolution: {integrity: sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==}
     peerDependencies:
       '@supabase/supabase-js': ^2.102.1
 
-  '@supabase/storage-js@2.103.0':
-    resolution: {integrity: sha512-DHmlvdAXwtOmZNbkIZi4lkobPR3XjIzoOgzoz5duMf6G+sDeY015YrzMJCnqdccuYr7X5x4yYuSwF//RoN2dvQ==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/storage-js@2.110.0':
+    resolution: {integrity: sha512-71+gU3HrhiylAhftY6FmO5PPdcsScnVcS766CVD+vTYK9qTDLbrx8FhgBYbqGm3iV/wkTfzrNJfjGsMeFRkJRQ==}
+    engines: {node: '>=22.0.0'}
 
-  '@supabase/supabase-js@2.103.0':
-    resolution: {integrity: sha512-j/6q5+LtXbR/YOLSLhy7Na74RD1cV2v+KwIIuuqMEjk1JpLEEyu0ynwDHpGoxMncDQl+R5FogaVqZm+85lZvtw==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/supabase-js@2.110.0':
+    resolution: {integrity: sha512-8yI84VJiEVW4zxZpLUmxXmjzQ7O2St9X/ymzlBETDHTURPWG3LmvbSiibq+7dqAJmyoUfxZnSfXeM4HCM8s4XQ==}
+    engines: {node: '>=22.0.0'}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1951,9 +1951,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/ws@8.18.1':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -6694,50 +6691,42 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@supabase/auth-js@2.103.0':
+  '@supabase/auth-js@2.110.0':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/functions-js@2.103.0':
+  '@supabase/functions-js@2.110.0':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/phoenix@0.4.0': {}
+  '@supabase/phoenix@0.4.4': {}
 
-  '@supabase/postgrest-js@2.103.0':
+  '@supabase/postgrest-js@2.110.0':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/realtime-js@2.103.0':
+  '@supabase/realtime-js@2.110.0':
     dependencies:
-      '@supabase/phoenix': 0.4.0
-      '@types/ws': 8.18.1
+      '@supabase/phoenix': 0.4.4
       tslib: 2.8.1
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
-  '@supabase/ssr@0.10.2(@supabase/supabase-js@2.103.0)':
+  '@supabase/ssr@0.10.2(@supabase/supabase-js@2.110.0)':
     dependencies:
-      '@supabase/supabase-js': 2.103.0
+      '@supabase/supabase-js': 2.110.0
       cookie: 1.1.1
 
-  '@supabase/storage-js@2.103.0':
+  '@supabase/storage-js@2.110.0':
     dependencies:
       iceberg-js: 0.8.1
       tslib: 2.8.1
 
-  '@supabase/supabase-js@2.103.0':
+  '@supabase/supabase-js@2.110.0':
     dependencies:
-      '@supabase/auth-js': 2.103.0
-      '@supabase/functions-js': 2.103.0
-      '@supabase/postgrest-js': 2.103.0
-      '@supabase/realtime-js': 2.103.0
-      '@supabase/storage-js': 2.103.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
+      '@supabase/auth-js': 2.110.0
+      '@supabase/functions-js': 2.110.0
+      '@supabase/postgrest-js': 2.110.0
+      '@supabase/realtime-js': 2.110.0
+      '@supabase/storage-js': 2.110.0
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -6985,10 +6974,6 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/ws@8.18.1':
-    dependencies:
-      '@types/node': 24.13.1
 
   '@types/yargs-parser@21.0.3': {}
 

--- a/src/app/__tests__/auth-fallback-guard.test.tsx
+++ b/src/app/__tests__/auth-fallback-guard.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AuthContext, type AuthContextType } from '@/lib/auth';
+import LoginPage from '@/app/login/page';
+import RegisterPage from '@/app/register/page';
+
+// The passkey/social buttons construct a Supabase client; stub it so the pages
+// render without touching the network.
+vi.mock('@/lib/supabase/client', () => ({
+    createClient: () => ({
+        auth: {
+            signInWithOAuth: vi.fn().mockResolvedValue({ error: null }),
+            signInWithPasskey: vi.fn().mockResolvedValue({ error: null }),
+        },
+    }),
+}));
+
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+const authValue: AuthContextType = {
+    user: null,
+    refresh: vi.fn(),
+    logout: vi.fn(),
+    isAuthenticated: false,
+};
+
+function renderWithAuth(node: React.ReactElement) {
+    return render(
+        <AuthContext.Provider value={authValue}>{node}</AuthContext.Provider>,
+    );
+}
+
+describe('email/password sign-in is always present (anti-lockout guard)', () => {
+    beforeEach(() => {
+        cleanup();
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    for (const flag of ['', 'true']) {
+        it(`keeps the login email/password form with the passkey flag = "${flag}"`, () => {
+            vi.stubEnv('NEXT_PUBLIC_ENABLE_PASSKEYS', flag);
+            renderWithAuth(<LoginPage />);
+            expect(screen.getByTestId('login-email')).toBeInTheDocument();
+            expect(screen.getByTestId('login-password')).toBeInTheDocument();
+            expect(screen.getByTestId('login-submit')).toBeInTheDocument();
+        });
+
+        it(`keeps the register email/password form with the passkey flag = "${flag}"`, () => {
+            vi.stubEnv('NEXT_PUBLIC_ENABLE_PASSKEYS', flag);
+            renderWithAuth(<RegisterPage />);
+            expect(screen.getByTestId('register-email')).toBeInTheDocument();
+            expect(screen.getByTestId('register-password')).toBeInTheDocument();
+            expect(screen.getByTestId('register-submit')).toBeInTheDocument();
+        });
+    }
+
+    it('hides the passkey sign-in button when the flag is off but keeps the password form', () => {
+        vi.stubEnv('NEXT_PUBLIC_ENABLE_PASSKEYS', '');
+        renderWithAuth(<LoginPage />);
+        expect(screen.queryByTestId('passkey-signin')).toBeNull();
+        expect(screen.getByTestId('login-password')).toBeInTheDocument();
+    });
+
+    it('shows the passkey sign-in button when the flag is on, alongside the password form', () => {
+        vi.stubEnv('NEXT_PUBLIC_ENABLE_PASSKEYS', 'true');
+        renderWithAuth(<LoginPage />);
+        expect(screen.getByTestId('passkey-signin')).toBeInTheDocument();
+        expect(screen.getByTestId('login-password')).toBeInTheDocument();
+    });
+});

--- a/src/app/__tests__/auth.pages.test.tsx
+++ b/src/app/__tests__/auth.pages.test.tsx
@@ -26,6 +26,12 @@ describe('Auth pages', () => {
         ).toBeInTheDocument();
     });
 
+    it('renders social login buttons on register', () => {
+        render(<RegisterPage />);
+        expect(screen.getByTestId('oauth-github')).toBeInTheDocument();
+        expect(screen.getByTestId('oauth-google')).toBeInTheDocument();
+    });
+
     it('renders login form', () => {
         render(<LoginPage />);
         expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
@@ -34,6 +40,12 @@ describe('Auth pages', () => {
             screen.getByRole('button', { name: /sign in/i }),
         ).toBeInTheDocument();
         expect(screen.getByText(/forgot password\?/i)).toBeInTheDocument();
+    });
+
+    it('renders social login buttons on login', () => {
+        render(<LoginPage />);
+        expect(screen.getByTestId('oauth-github')).toBeInTheDocument();
+        expect(screen.getByTestId('oauth-google')).toBeInTheDocument();
     });
 
     it('renders forgot-password form', () => {

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -2,6 +2,7 @@
 import { useContext } from 'react';
 import { AuthContext } from '@/lib/auth';
 import { useRouter } from 'next/navigation';
+import PasskeyManager from '@/components/auth/PasskeyManager';
 
 export default function AccountPage() {
     const { user, logout, isAuthenticated } = useContext(AuthContext);
@@ -62,6 +63,7 @@ export default function AccountPage() {
                     Sign out
                 </button>
             </div>
+            <PasskeyManager />
         </div>
     );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,7 @@ import type React from 'react';
 import { useState, useContext } from 'react';
 import { useRouter } from 'next/navigation';
 import { AuthContext } from '@/lib/auth';
+import SocialAuthButtons from '@/components/auth/SocialAuthButtons';
 
 export default function LoginPage() {
     const router = useRouter();
@@ -101,6 +102,15 @@ export default function LoginPage() {
                     </a>
                 </div>
             </form>
+            <div
+                className="my-6 flex items-center gap-3 text-sm text-[var(--color-norwegian-700)]"
+                aria-hidden="true"
+            >
+                <span className="h-px flex-1 bg-current opacity-30" />
+                <span>or</span>
+                <span className="h-px flex-1 bg-current opacity-30" />
+            </div>
+            <SocialAuthButtons />
         </div>
     );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,6 +4,7 @@ import { useState, useContext } from 'react';
 import { useRouter } from 'next/navigation';
 import { AuthContext } from '@/lib/auth';
 import SocialAuthButtons from '@/components/auth/SocialAuthButtons';
+import PasskeySignInButton from '@/components/auth/PasskeySignInButton';
 
 export default function LoginPage() {
     const router = useRouter();
@@ -111,6 +112,7 @@ export default function LoginPage() {
                 <span className="h-px flex-1 bg-current opacity-30" />
             </div>
             <SocialAuthButtons />
+            <PasskeySignInButton next="/" />
         </div>
     );
 }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -2,6 +2,7 @@
 import type React from 'react';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import SocialAuthButtons from '@/components/auth/SocialAuthButtons';
 
 export default function RegisterPage() {
     const router = useRouter();
@@ -109,6 +110,15 @@ export default function RegisterPage() {
                     </button>
                 </div>
             </form>
+            <div
+                className="my-6 flex items-center gap-3 text-sm text-[var(--color-norwegian-700)]"
+                aria-hidden="true"
+            >
+                <span className="h-px flex-1 bg-current opacity-30" />
+                <span>or</span>
+                <span className="h-px flex-1 bg-current opacity-30" />
+            </div>
+            <SocialAuthButtons />
         </div>
     );
 }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -3,6 +3,7 @@ import type React from 'react';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import SocialAuthButtons from '@/components/auth/SocialAuthButtons';
+import PasskeySignInButton from '@/components/auth/PasskeySignInButton';
 
 export default function RegisterPage() {
     const router = useRouter();
@@ -119,6 +120,7 @@ export default function RegisterPage() {
                 <span className="h-px flex-1 bg-current opacity-30" />
             </div>
             <SocialAuthButtons />
+            <PasskeySignInButton next="/" />
         </div>
     );
 }

--- a/src/components/__tests__/PasskeyManager.test.tsx
+++ b/src/components/__tests__/PasskeyManager.test.tsx
@@ -1,0 +1,119 @@
+import {
+    render,
+    screen,
+    fireEvent,
+    waitFor,
+    cleanup,
+} from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import PasskeyManager from '@/components/auth/PasskeyManager';
+
+const list = vi.fn();
+const registerPasskey = vi.fn();
+const passkeyDelete = vi.fn();
+const update = vi.fn();
+
+vi.mock('@/lib/supabase/client', () => ({
+    createClient: () => ({
+        auth: {
+            registerPasskey,
+            passkey: { list, delete: passkeyDelete, update },
+        },
+    }),
+}));
+
+const SAMPLE = [
+    {
+        id: 'pk-1',
+        friendly_name: 'MacBook Touch ID',
+        created_at: '2026-06-01T00:00:00.000Z',
+        last_used_at: '2026-06-20T00:00:00.000Z',
+    },
+    {
+        id: 'pk-2',
+        friendly_name: 'iPhone',
+        created_at: '2026-06-10T00:00:00.000Z',
+    },
+];
+
+describe('PasskeyManager', () => {
+    beforeEach(() => {
+        list.mockReset();
+        registerPasskey.mockReset();
+        passkeyDelete.mockReset();
+        update.mockReset();
+        list.mockResolvedValue({ data: SAMPLE, error: null });
+        registerPasskey.mockResolvedValue({ data: {}, error: null });
+        passkeyDelete.mockResolvedValue({ data: null, error: null });
+        update.mockResolvedValue({ data: SAMPLE[0], error: null });
+        cleanup();
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('renders nothing when the passkey flag is off', () => {
+        vi.stubEnv('NEXT_PUBLIC_ENABLE_PASSKEYS', '');
+        const { container } = render(<PasskeyManager />);
+        expect(container).toBeEmptyDOMElement();
+        expect(list).not.toHaveBeenCalled();
+    });
+
+    it('lists the user passkeys when the flag is on', async () => {
+        vi.stubEnv('NEXT_PUBLIC_ENABLE_PASSKEYS', 'true');
+        render(<PasskeyManager />);
+        await waitFor(() => expect(list).toHaveBeenCalledTimes(1));
+        expect(await screen.findByText('MacBook Touch ID')).toBeInTheDocument();
+        expect(screen.getByText('iPhone')).toBeInTheDocument();
+    });
+
+    it('adds a passkey via registerPasskey then reloads the list', async () => {
+        vi.stubEnv('NEXT_PUBLIC_ENABLE_PASSKEYS', 'true');
+        render(<PasskeyManager />);
+        await waitFor(() => expect(list).toHaveBeenCalledTimes(1));
+        fireEvent.click(screen.getByTestId('passkey-add'));
+        await waitFor(() => expect(registerPasskey).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(list).toHaveBeenCalledTimes(2));
+    });
+
+    it('deletes a passkey with the passkeyId', async () => {
+        vi.stubEnv('NEXT_PUBLIC_ENABLE_PASSKEYS', 'true');
+        render(<PasskeyManager />);
+        await waitFor(() => expect(list).toHaveBeenCalledTimes(1));
+        fireEvent.click(await screen.findByTestId('passkey-delete-pk-1'));
+        await waitFor(() =>
+            expect(passkeyDelete).toHaveBeenCalledWith({ passkeyId: 'pk-1' }),
+        );
+    });
+
+    it('renames a passkey via update with friendlyName', async () => {
+        vi.stubEnv('NEXT_PUBLIC_ENABLE_PASSKEYS', 'true');
+        render(<PasskeyManager />);
+        await waitFor(() => expect(list).toHaveBeenCalledTimes(1));
+        fireEvent.click(await screen.findByTestId('passkey-rename-pk-2'));
+        const input = screen.getByTestId('passkey-rename-input-pk-2');
+        fireEvent.change(input, { target: { value: 'My Phone' } });
+        fireEvent.click(screen.getByTestId('passkey-rename-save-pk-2'));
+        await waitFor(() =>
+            expect(update).toHaveBeenCalledWith({
+                passkeyId: 'pk-2',
+                friendlyName: 'My Phone',
+            }),
+        );
+    });
+
+    it('shows a friendly message when a credential already exists', async () => {
+        vi.stubEnv('NEXT_PUBLIC_ENABLE_PASSKEYS', 'true');
+        registerPasskey.mockResolvedValueOnce({
+            data: null,
+            error: { code: 'webauthn_credential_exists', message: 'exists' },
+        });
+        render(<PasskeyManager />);
+        await waitFor(() => expect(list).toHaveBeenCalledTimes(1));
+        fireEvent.click(screen.getByTestId('passkey-add'));
+        expect(
+            await screen.findByText(/already registered/i),
+        ).toBeInTheDocument();
+    });
+});

--- a/src/components/__tests__/PasskeySignInButton.test.tsx
+++ b/src/components/__tests__/PasskeySignInButton.test.tsx
@@ -1,0 +1,76 @@
+import {
+    render,
+    screen,
+    fireEvent,
+    waitFor,
+    cleanup,
+} from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import PasskeySignInButton from '@/components/auth/PasskeySignInButton';
+
+const signInWithPasskey = vi.fn();
+const push = vi.fn();
+const refresh = vi.fn();
+
+vi.mock('@/lib/supabase/client', () => ({
+    createClient: () => ({
+        auth: { signInWithPasskey },
+    }),
+}));
+
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({ push, refresh }),
+}));
+
+describe('PasskeySignInButton', () => {
+    beforeEach(() => {
+        signInWithPasskey.mockReset();
+        signInWithPasskey.mockResolvedValue({ data: {}, error: null });
+        push.mockReset();
+        refresh.mockReset();
+        cleanup();
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('renders nothing when the passkey flag is off', () => {
+        vi.stubEnv('NEXT_PUBLIC_ENABLE_PASSKEYS', '');
+        const { container } = render(<PasskeySignInButton />);
+        expect(container).toBeEmptyDOMElement();
+        expect(screen.queryByTestId('passkey-signin')).toBeNull();
+    });
+
+    it('renders the button when the flag is on', () => {
+        vi.stubEnv('NEXT_PUBLIC_ENABLE_PASSKEYS', 'true');
+        render(<PasskeySignInButton />);
+        expect(screen.getByTestId('passkey-signin')).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /sign in with a passkey/i }),
+        ).toBeInTheDocument();
+    });
+
+    it('calls signInWithPasskey and navigates on success', async () => {
+        vi.stubEnv('NEXT_PUBLIC_ENABLE_PASSKEYS', 'true');
+        render(<PasskeySignInButton next="/account" />);
+        fireEvent.click(screen.getByTestId('passkey-signin'));
+        await waitFor(() => expect(signInWithPasskey).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(push).toHaveBeenCalledWith('/account'));
+        expect(refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders an error when sign-in fails', async () => {
+        vi.stubEnv('NEXT_PUBLIC_ENABLE_PASSKEYS', 'true');
+        signInWithPasskey.mockResolvedValueOnce({
+            data: null,
+            error: { message: 'No passkey available' },
+        });
+        render(<PasskeySignInButton />);
+        fireEvent.click(screen.getByTestId('passkey-signin'));
+        expect(
+            await screen.findByText(/no passkey available/i),
+        ).toBeInTheDocument();
+        expect(push).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/__tests__/SocialAuthButtons.test.tsx
+++ b/src/components/__tests__/SocialAuthButtons.test.tsx
@@ -1,0 +1,90 @@
+import {
+    render,
+    screen,
+    fireEvent,
+    waitFor,
+    cleanup,
+} from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import SocialAuthButtons from '@/components/auth/SocialAuthButtons';
+
+const signInWithOAuth = vi.fn();
+
+vi.mock('@/lib/supabase/client', () => ({
+    createClient: () => ({
+        auth: { signInWithOAuth },
+    }),
+}));
+
+describe('SocialAuthButtons', () => {
+    beforeEach(() => {
+        signInWithOAuth.mockReset();
+        signInWithOAuth.mockResolvedValue({ error: null });
+        cleanup();
+    });
+
+    it('renders GitHub and Google buttons', () => {
+        render(<SocialAuthButtons />);
+        expect(screen.getByTestId('oauth-github')).toBeInTheDocument();
+        expect(screen.getByTestId('oauth-google')).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /continue with github/i }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /continue with google/i }),
+        ).toBeInTheDocument();
+    });
+
+    it('signs in with GitHub using the callback redirect', async () => {
+        render(<SocialAuthButtons />);
+        fireEvent.click(screen.getByTestId('oauth-github'));
+        await waitFor(() =>
+            expect(signInWithOAuth).toHaveBeenCalledTimes(1),
+        );
+        expect(signInWithOAuth).toHaveBeenCalledWith({
+            provider: 'github',
+            options: {
+                redirectTo: `${window.location.origin}/auth/callback`,
+            },
+        });
+    });
+
+    it('signs in with Google using the callback redirect', async () => {
+        render(<SocialAuthButtons />);
+        fireEvent.click(screen.getByTestId('oauth-google'));
+        await waitFor(() =>
+            expect(signInWithOAuth).toHaveBeenCalledTimes(1),
+        );
+        expect(signInWithOAuth).toHaveBeenCalledWith({
+            provider: 'google',
+            options: {
+                redirectTo: `${window.location.origin}/auth/callback`,
+            },
+        });
+    });
+
+    it('appends a next param to the redirect when provided', async () => {
+        render(<SocialAuthButtons next="/account" />);
+        fireEvent.click(screen.getByTestId('oauth-github'));
+        await waitFor(() =>
+            expect(signInWithOAuth).toHaveBeenCalledTimes(1),
+        );
+        expect(signInWithOAuth).toHaveBeenCalledWith({
+            provider: 'github',
+            options: {
+                redirectTo: `${window.location.origin}/auth/callback?next=%2Faccount`,
+            },
+        });
+    });
+
+    it('surfaces an error when sign-in fails', async () => {
+        signInWithOAuth.mockResolvedValueOnce({
+            error: { message: 'OAuth provider unavailable' },
+        });
+        render(<SocialAuthButtons />);
+        fireEvent.click(screen.getByTestId('oauth-google'));
+        expect(
+            await screen.findByText(/oauth provider unavailable/i),
+        ).toBeInTheDocument();
+    });
+});

--- a/src/components/auth/PasskeyManager.tsx
+++ b/src/components/auth/PasskeyManager.tsx
@@ -1,0 +1,296 @@
+'use client';
+import { useCallback, useEffect, useState } from 'react';
+import { createClient } from '@/lib/supabase/client';
+
+/** Shape of a passkey list item returned by `auth.passkey.list()`. */
+interface Passkey {
+    id: string;
+    friendly_name?: string;
+    created_at: string;
+    last_used_at?: string;
+}
+
+/**
+ * Map an experimental passkey error (AuthError or WebAuthnError) to a friendly,
+ * user-facing message. Handles the documented experimental error codes plus the
+ * user-cancelled ceremony case.
+ */
+function friendlyError(
+    error: { code?: string; name?: string; message?: string } | null,
+    fallback: string,
+): string {
+    if (!error) return fallback;
+    switch (error.code) {
+        case 'webauthn_credential_exists':
+            return 'That passkey is already registered.';
+        case 'ERROR_CEREMONY_ABORTED':
+            return 'Passkey prompt was cancelled.';
+        default:
+            // The browser surfaces a user cancellation as a DOMException too.
+            if (error.name === 'NotAllowedError') {
+                return 'Passkey prompt was cancelled.';
+            }
+            return error.message || fallback;
+    }
+}
+
+function formatDate(value: string): string {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+    return date.toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+    });
+}
+
+/**
+ * Passkey management (enroll / list / rename / delete) for the signed-in user.
+ *
+ * Gated behind `NEXT_PUBLIC_ENABLE_PASSKEYS === 'true'` (ADR 0006). When the
+ * flag is off this renders nothing. The caller is responsible for only mounting
+ * it for an authenticated user; it is strictly additive and never replaces any
+ * existing sign-in method. The flag is read at call time so tests can stub it.
+ */
+export default function PasskeyManager() {
+    const [passkeys, setPasskeys] = useState<Passkey[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [editingId, setEditingId] = useState<string | null>(null);
+    const [editingName, setEditingName] = useState('');
+
+    const enabled = process.env.NEXT_PUBLIC_ENABLE_PASSKEYS === 'true';
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        try {
+            const supabase = createClient();
+            const { data, error: listError } =
+                await supabase.auth.passkey.list();
+            if (listError) {
+                setError(
+                    friendlyError(listError, 'Could not load your passkeys.'),
+                );
+                setPasskeys([]);
+                return;
+            }
+            setError(null);
+            setPasskeys((data ?? []) as Passkey[]);
+        } catch {
+            setError('Could not load your passkeys.');
+            setPasskeys([]);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!enabled) return;
+        void load();
+    }, [enabled, load]);
+
+    if (!enabled) {
+        return null;
+    }
+
+    async function addPasskey() {
+        setError(null);
+        setBusy(true);
+        try {
+            const supabase = createClient();
+            const { error: registerError } =
+                await supabase.auth.registerPasskey();
+            if (registerError) {
+                setError(
+                    friendlyError(registerError, 'Could not add a passkey.'),
+                );
+                return;
+            }
+            await load();
+        } catch {
+            setError('Could not add a passkey.');
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    async function deletePasskey(passkeyId: string) {
+        setError(null);
+        setBusy(true);
+        try {
+            const supabase = createClient();
+            const { error: deleteError } = await supabase.auth.passkey.delete({
+                passkeyId,
+            });
+            if (deleteError) {
+                setError(
+                    friendlyError(deleteError, 'Could not delete the passkey.'),
+                );
+                return;
+            }
+            await load();
+        } catch {
+            setError('Could not delete the passkey.');
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    function startRename(passkey: Passkey) {
+        setEditingId(passkey.id);
+        setEditingName(passkey.friendly_name ?? '');
+    }
+
+    function cancelRename() {
+        setEditingId(null);
+        setEditingName('');
+    }
+
+    async function saveRename(passkeyId: string) {
+        setError(null);
+        setBusy(true);
+        try {
+            const supabase = createClient();
+            const { error: updateError } = await supabase.auth.passkey.update({
+                passkeyId,
+                friendlyName: editingName,
+            });
+            if (updateError) {
+                setError(
+                    friendlyError(updateError, 'Could not rename the passkey.'),
+                );
+                return;
+            }
+            cancelRename();
+            await load();
+        } catch {
+            setError('Could not rename the passkey.');
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    return (
+        <section data-testid="passkey-manager" className="mt-8">
+            <h2 className="text-xl font-semibold mb-2">Passkeys</h2>
+            <p className="mb-4 text-sm">
+                Passkeys let you sign in with your device&apos;s biometrics or
+                screen lock. They are an additional sign-in method — your
+                password and magic-link still work.
+            </p>
+            <div className="mb-4">
+                <button
+                    type="button"
+                    data-testid="passkey-add"
+                    className="btn btn--primary"
+                    disabled={busy}
+                    onClick={addPasskey}
+                >
+                    {busy ? 'Working…' : 'Add a passkey'}
+                </button>
+            </div>
+            {error ? (
+                <div role="alert" className="mb-4 text-sm text-red-600">
+                    {error}
+                </div>
+            ) : null}
+            {loading ? (
+                <p className="text-sm" data-testid="passkey-loading">
+                    Loading passkeys…
+                </p>
+            ) : passkeys.length === 0 ? (
+                <p className="text-sm" data-testid="passkey-empty">
+                    You have no passkeys yet.
+                </p>
+            ) : (
+                <ul data-testid="passkey-list" className="space-y-3">
+                    {passkeys.map((passkey) => (
+                        <li
+                            key={passkey.id}
+                            data-testid={`passkey-item-${passkey.id}`}
+                            className="flex flex-wrap items-center justify-between gap-3 rounded border border-[var(--color-norwegian-200)] p-3"
+                        >
+                            {editingId === passkey.id ? (
+                                <div className="flex flex-1 flex-wrap items-center gap-2">
+                                    <label
+                                        htmlFor={`passkey-name-${passkey.id}`}
+                                        className="sr-only"
+                                    >
+                                        Passkey name
+                                    </label>
+                                    <input
+                                        id={`passkey-name-${passkey.id}`}
+                                        data-testid={`passkey-rename-input-${passkey.id}`}
+                                        className="form-input flex-1"
+                                        value={editingName}
+                                        onChange={(e) =>
+                                            setEditingName(e.target.value)
+                                        }
+                                        maxLength={120}
+                                    />
+                                    <button
+                                        type="button"
+                                        data-testid={`passkey-rename-save-${passkey.id}`}
+                                        className="btn btn--primary"
+                                        disabled={busy}
+                                        onClick={() => saveRename(passkey.id)}
+                                    >
+                                        Save
+                                    </button>
+                                    <button
+                                        type="button"
+                                        data-testid={`passkey-rename-cancel-${passkey.id}`}
+                                        className="btn"
+                                        disabled={busy}
+                                        onClick={cancelRename}
+                                    >
+                                        Cancel
+                                    </button>
+                                </div>
+                            ) : (
+                                <>
+                                    <div className="min-w-0">
+                                        <p className="font-medium">
+                                            {passkey.friendly_name ||
+                                                'Unnamed passkey'}
+                                        </p>
+                                        <p className="text-xs">
+                                            Added{' '}
+                                            {formatDate(passkey.created_at)}
+                                            {passkey.last_used_at
+                                                ? ` · Last used ${formatDate(passkey.last_used_at)}`
+                                                : ''}
+                                        </p>
+                                    </div>
+                                    <div className="flex gap-2">
+                                        <button
+                                            type="button"
+                                            data-testid={`passkey-rename-${passkey.id}`}
+                                            className="btn"
+                                            disabled={busy}
+                                            onClick={() => startRename(passkey)}
+                                        >
+                                            Rename
+                                        </button>
+                                        <button
+                                            type="button"
+                                            data-testid={`passkey-delete-${passkey.id}`}
+                                            className="btn"
+                                            disabled={busy}
+                                            onClick={() =>
+                                                deletePasskey(passkey.id)
+                                            }
+                                        >
+                                            Delete
+                                        </button>
+                                    </div>
+                                </>
+                            )}
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </section>
+    );
+}

--- a/src/components/auth/PasskeySignInButton.tsx
+++ b/src/components/auth/PasskeySignInButton.tsx
@@ -1,0 +1,72 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createClient } from '@/lib/supabase/client';
+
+interface PasskeySignInButtonProps {
+    /** Path to return to after a successful sign-in. Defaults to `/`. */
+    next?: string;
+}
+
+/**
+ * "Sign in with a passkey" button (WebAuthn discoverable credentials).
+ *
+ * Strictly additive and gated behind `NEXT_PUBLIC_ENABLE_PASSKEYS === 'true'`
+ * (ADR 0006). When the flag is off this renders nothing, leaving the
+ * email/password and magic-link paths untouched. The flag is read at call time
+ * (not module scope) so tests can stub it per-case.
+ */
+export default function PasskeySignInButton({
+    next = '/',
+}: PasskeySignInButtonProps) {
+    const router = useRouter();
+    const [pending, setPending] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    if (process.env.NEXT_PUBLIC_ENABLE_PASSKEYS !== 'true') {
+        return null;
+    }
+
+    async function signIn() {
+        setError(null);
+        setPending(true);
+        try {
+            const supabase = createClient();
+            const { error: passkeyError } =
+                await supabase.auth.signInWithPasskey();
+            if (passkeyError) {
+                setError(
+                    passkeyError.message ||
+                        'Passkey sign-in failed. Please try again.',
+                );
+                setPending(false);
+                return;
+            }
+            router.push(next ?? '/');
+            router.refresh();
+        } catch {
+            setError('Passkey sign-in failed. Please try again.');
+            setPending(false);
+        }
+    }
+
+    return (
+        <div className="mt-3 space-y-3">
+            <button
+                type="button"
+                data-testid="passkey-signin"
+                aria-label="Sign in with a passkey"
+                className="btn btn--outline w-full"
+                disabled={pending}
+                onClick={signIn}
+            >
+                {pending ? 'Signing in…' : 'Sign in with a passkey'}
+            </button>
+            {error ? (
+                <div role="alert" className="text-sm text-red-600">
+                    {error}
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/src/components/auth/SocialAuthButtons.tsx
+++ b/src/components/auth/SocialAuthButtons.tsx
@@ -1,0 +1,123 @@
+'use client';
+import { useState } from 'react';
+import { createClient } from '@/lib/supabase/client';
+
+type OAuthProvider = 'github' | 'google';
+
+interface ProviderConfig {
+    provider: OAuthProvider;
+    label: string;
+    icon: React.ReactNode;
+}
+
+function GitHubIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            focusable="false"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+        >
+            <path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.438 9.8 8.205 11.387.6.113.82-.26.82-.577 0-.285-.01-1.04-.016-2.04-3.338.726-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.09-.745.083-.73.083-.73 1.205.085 1.84 1.237 1.84 1.237 1.07 1.835 2.807 1.305 3.492.998.108-.776.42-1.305.762-1.605-2.665-.303-5.467-1.332-5.467-5.93 0-1.31.468-2.382 1.236-3.222-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.3 1.23a11.5 11.5 0 0 1 3.003-.404c1.02.005 2.047.138 3.006.404 2.29-1.552 3.297-1.23 3.297-1.23.653 1.652.242 2.873.118 3.176.77.84 1.235 1.912 1.235 3.222 0 4.61-2.806 5.624-5.48 5.92.43.372.814 1.103.814 2.222 0 1.604-.015 2.898-.015 3.293 0 .32.216.694.825.576C20.565 22.296 24 17.798 24 12.5 24 5.87 18.627.5 12 .5Z" />
+        </svg>
+    );
+}
+
+function GoogleIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            focusable="false"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+        >
+            <path
+                fill="#4285F4"
+                d="M23.52 12.27c0-.79-.07-1.54-.2-2.27H12v4.51h6.47a5.53 5.53 0 0 1-2.4 3.63v3h3.88c2.27-2.09 3.57-5.17 3.57-8.87Z"
+            />
+            <path
+                fill="#34A853"
+                d="M12 24c3.24 0 5.96-1.08 7.95-2.91l-3.88-3c-1.08.72-2.45 1.15-4.07 1.15-3.13 0-5.78-2.11-6.73-4.96H1.29v3.09A12 12 0 0 0 12 24Z"
+            />
+            <path
+                fill="#FBBC05"
+                d="M5.27 14.28a7.2 7.2 0 0 1 0-4.56V6.63H1.29a12 12 0 0 0 0 10.74l3.98-3.09Z"
+            />
+            <path
+                fill="#EA4335"
+                d="M12 4.75c1.77 0 3.35.61 4.6 1.8l3.44-3.44A11.5 11.5 0 0 0 12 0 12 12 0 0 0 1.29 6.63l3.98 3.09C6.22 6.86 8.87 4.75 12 4.75Z"
+            />
+        </svg>
+    );
+}
+
+const PROVIDERS: ProviderConfig[] = [
+    { provider: 'github', label: 'Continue with GitHub', icon: <GitHubIcon /> },
+    { provider: 'google', label: 'Continue with Google', icon: <GoogleIcon /> },
+];
+
+interface SocialAuthButtonsProps {
+    /** Path to return to after a successful sign-in. Defaults to `/`. */
+    next?: string;
+}
+
+export default function SocialAuthButtons({
+    next = '/',
+}: SocialAuthButtonsProps) {
+    const [pending, setPending] = useState<OAuthProvider | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    async function signIn(provider: OAuthProvider) {
+        setError(null);
+        setPending(provider);
+        try {
+            const supabase = createClient();
+            const callback = new URL('/auth/callback', window.location.origin);
+            if (next && next !== '/') {
+                callback.searchParams.set('next', next);
+            }
+            const { error: oauthError } = await supabase.auth.signInWithOAuth({
+                provider,
+                options: { redirectTo: callback.toString() },
+            });
+            if (oauthError) {
+                setError(oauthError.message || 'Sign-in failed. Please try again.');
+                setPending(null);
+            }
+            // On success the browser is redirected to the provider; no further
+            // work is needed here.
+        } catch {
+            setError('Sign-in failed. Please try again.');
+            setPending(null);
+        }
+    }
+
+    return (
+        <div className="space-y-3">
+            {PROVIDERS.map(({ provider, label, icon }) => (
+                <button
+                    key={provider}
+                    type="button"
+                    data-testid={`oauth-${provider}`}
+                    aria-label={label}
+                    className="btn btn--outline w-full gap-2"
+                    disabled={pending !== null}
+                    onClick={() => signIn(provider)}
+                >
+                    {icon}
+                    <span>
+                        {pending === provider ? 'Redirecting…' : label}
+                    </span>
+                </button>
+            ))}
+            {error ? (
+                <div role="alert" className="text-sm text-red-600">
+                    {error}
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,12 +1,27 @@
 import { createBrowserClient } from '@supabase/ssr';
 
 /**
+ * Whether passkey (WebAuthn) support is enabled. Gated by an env flag so the
+ * experimental Supabase passkey API can be turned off instantly (ADR 0006).
+ * Read once at module scope so the value is stable per build.
+ */
+export const passkeysEnabled =
+    process.env.NEXT_PUBLIC_ENABLE_PASSKEYS === 'true';
+
+/**
  * Create a Supabase client for use in browser/client components
- * Uses environment variables to configure the connection
+ * Uses environment variables to configure the connection.
+ *
+ * When `NEXT_PUBLIC_ENABLE_PASSKEYS === 'true'` the experimental passkey API is
+ * opted in via `auth.experimental.passkey`; otherwise the client is created
+ * exactly as before (no experimental opt-in).
  */
 export const createClient = () => {
     return createBrowserClient(
         process.env.NEXT_PUBLIC_SUPABASE_URL!,
         process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+        passkeysEnabled
+            ? { auth: { experimental: { passkey: true } } }
+            : undefined,
     );
 };


### PR DESCRIPTION
Implements **ADR 0006** — modernizes auth on top of the existing Supabase setup with **social login (GitHub + Google)** and **passkeys / WebAuthn (biometric)**. Strictly additive: email/password + magic-link are untouched and remain the recovery floor.

## What's included
- **ADR 0006** (`docs/adr/0006-auth-modernization-social-passkeys.md`, accepted) — drivers/NFRs, options, identity-linking policy, anti-lockout strategy, CI/e2e impact, rollout. Removed an empty placeholder ADR.
- **Social login (GitHub + Google)** — `SocialAuthButtons` on `/login` and `/register` calling `signInWithOAuth`, redirecting through the existing `/auth/callback` (`exchangeCodeForSession`, unchanged). GA, no client bump. **Verified working locally.**
- **Passkeys (experimental)** — `@supabase/supabase-js` 2.103 → 2.110 (ssr 0.10.2 interop verified), client opts into `auth.experimental.passkey` **only when `NEXT_PUBLIC_ENABLE_PASSKEYS === 'true'`**. "Sign in with a passkey" on `/login` + `/register`; enroll/list/rename/delete on the account page.

## Safety / additive guarantees
- Email/password + magic-link **unchanged** — they stay the e2e login path and the no-lockout recovery floor. An **anti-lockout guard test** asserts the password form survives both flag states.
- Passkeys ship **dormant**: with the flag unset (the default, incl. CI), none of the passkey UI renders and the browser client is byte-for-byte the previous client. Safe to merge before enabling.
- Callback route, `auth-guard.ts`, admin/bets/books code all untouched.
- Identity-linking relies on Supabase auto-link **on verified email** (`brn.dbn@gmail.com` is verified on GitHub + Google → resolves to the existing admin user, preserving `app_metadata.role`).

## Config status
- Supabase dashboard already configured (GitHub + Google providers; redirect URLs; passkeys RP ID `bryandebaun.dev`, prod origin only).
- To enable passkeys post-merge: set `NEXT_PUBLIC_ENABLE_PASSKEYS=true` in Vercel + redeploy. The WebAuthn ceremony only works on `https://bryandebaun.dev` (not localhost/previews) — documented in the README.

## Tests
336 passing (16 new): social buttons call `signInWithOAuth` with the right provider/redirect; passkey sign-in + management gated by the flag; anti-lockout guard. No real OAuth/WebAuthn ceremony in CI. lint + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
