### PR TITLE
chore: add Doppler secrets management + .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,57 @@
+# Example environment variables for bryandebaun.dev.
+# Copy to .env.local and fill in real values, or manage via Doppler (`doppler run --`).
+# NEXT_PUBLIC_* are exposed to the browser at build time; everything else is server-only.
+# See docs/secrets-doppler.md.
+
+# ── MCP server (data plane) ───────────────────────────────────────────────────
+MCP_BASE_URL=https://bad-mcp.onrender.com
+MCP_API_KEY=changeme                       # server-to-server key for the MCP API
+MCP_OPENAPI_URL=                           # optional: OpenAPI spec URL for client generation
+MCP_USER_AGENT=                            # optional: custom User-Agent for MCP requests
+
+# ── Vercel MCP (optional tooling) ─────────────────────────────────────────────
+VERCEL_MCP_TOKEN=changeme
+VERCEL_MCP_URL=
+
+# ── Site ──────────────────────────────────────────────────────────────────────
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# ── Supabase Auth ─────────────────────────────────────────────────────────────
+# https://supabase.com/dashboard/project/YOUR_PROJECT_ID/settings/api
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_changeme
+SUPABASE_SECRET_KEY=changeme               # service role key (server-only admin ops)
+# SUPABASE_SERVICE_ROLE_KEY also accepted as an alias
+
+# ── Email (Resend) ────────────────────────────────────────────────────────────
+RESEND_API_KEY=re_changeme
+CONTACT_FROM_EMAIL="bryandebaun.dev <noreply@yourdomain.com>"
+CONTACT_TO_EMAIL=you@example.com
+
+# ── OAuth providers ───────────────────────────────────────────────────────────
+GITHUB_OAUTH_CLIENT_ID=changeme
+GITHUB_OAUTH_CLIENT_SECRET=changeme
+GOOGLE_OAUTH_CLIENT_ID=changeme
+GOOGLE_OAUTH_CLIENT_SECRET=changeme
+
+# ── GitHub API (optional; raises rate limit) ──────────────────────────────────
+GITHUB_TOKEN=github_pat_changeme
+
+# ── ISR / revalidation ────────────────────────────────────────────────────────
+REVALIDATE_SECRET=changeme                 # protects the /api/revalidate endpoint
+
+# ── Feature flags ─────────────────────────────────────────────────────────────
+NEXT_PUBLIC_ENABLE_PASSKEYS=0              # '1' to enable WebAuthn UI (production origin only)
+
+# ── Debug (dev only) ──────────────────────────────────────────────────────────
+DEBUG_MCP=0
+DEBUG_AUTH=0
+DEBUG_FETCH=0
+
+# ── Test fixtures (local / CI only) ───────────────────────────────────────────
+ADMIN_TEST_EMAIL=you@example.com
+ADMIN_TEST_PASSWORD=changeme
+E2E_ADMIN_EMAIL=e2e-admin@example.com
+E2E_ADMIN_PASSWORD=changeme
+E2E_USER_EMAIL=e2e-user@example.com
+E2E_USER_PASSWORD=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/docs/secrets-doppler.md
+++ b/docs/secrets-doppler.md
@@ -1,0 +1,58 @@
+# Secrets management with Doppler
+
+This repo's environment variables are managed in **[Doppler](https://www.doppler.com/)**
+— a cloud secrets store — instead of hand-copying `.env.local` between machines.
+
+- **Values, not files.** Doppler stores each variable as a discrete key/value; each
+  machine reconstructs the environment via the CLI. No `.env` is copied.
+- **Two configs:** `dev` (local) and `prd` (production on Vercel).
+- **`NEXT_PUBLIC_*`** are build-time public values baked into the client bundle — Doppler
+  injects them at build just like server-only vars.
+- `doppler.yaml` pins project `bryandebaun` / config `dev` so every machine
+  auto-configures. `.env.example` documents every variable (placeholders only).
+
+## One-time: create the project (owner, once)
+
+Create Doppler project **`bryandebaun`** (configs `dev`, `prd`), then bootstrap `dev`:
+
+```powershell
+doppler login                          # browser auth
+doppler projects create bryandebaun    # or create it in the dashboard
+doppler setup                          # reads doppler.yaml → bryandebaun / dev
+doppler secrets upload .env.local      # push local values into the dev config (one time)
+```
+
+Populate `prd` with production values in the dashboard (or `doppler secrets set
+--config prd`). See `.env.example` for the full variable list.
+
+## Per machine (PC, Mac, …)
+
+```powershell
+doppler login
+doppler setup            # auto-selects bryandebaun / dev from doppler.yaml
+doppler run -- pnpm dev  # injects secrets into the process
+```
+
+## Daily use — prefix commands with `doppler run --`
+
+Package scripts are unchanged; run them through Doppler for managed secrets:
+
+```powershell
+doppler run -- pnpm dev            # next dev --turbopack
+doppler run -- pnpm run build      # build:packages → tsx scripts/build.ts
+doppler run -- pnpm start          # next start
+```
+
+## Production (Vercel)
+
+Vercel injects env vars per environment (Production / Preview / Development) from the
+dashboard today. To make Doppler the source of truth, connect Doppler's **native Vercel
+integration** and map the `prd` config → Vercel **Production** (and, later, a config →
+**Preview**). `NEXT_PUBLIC_*` values are read at build time on Vercel as usual.
+
+## Rotate after migrating
+
+Migration is the moment to rotate the sensitive secrets that have lived in `.env.local`:
+`MCP_API_KEY`, `SUPABASE_SECRET_KEY`, `RESEND_API_KEY`, `REVALIDATE_SECRET`,
+`GITHUB_TOKEN`, `GITHUB_OAUTH_CLIENT_SECRET`, `GOOGLE_OAUTH_CLIENT_SECRET`, and the
+`VERCEL_MCP_TOKEN`.

--- a/docs/secrets-doppler.md
+++ b/docs/secrets-doppler.md
@@ -8,17 +8,17 @@ This repo's environment variables are managed in **[Doppler](https://www.doppler
 - **Two configs:** `dev` (local) and `prd` (production on Vercel).
 - **`NEXT_PUBLIC_*`** are build-time public values baked into the client bundle — Doppler
   injects them at build just like server-only vars.
-- `doppler.yaml` pins project `bryandebaun` / config `dev` so every machine
+- `doppler.yaml` pins project `bryandebaun-dev` / config `dev` so every machine
   auto-configures. `.env.example` documents every variable (placeholders only).
 
 ## One-time: create the project (owner, once)
 
-Create Doppler project **`bryandebaun`** (configs `dev`, `prd`), then bootstrap `dev`:
+Create Doppler project **`bryandebaun-dev`** (configs `dev`, `prd`), then bootstrap `dev`:
 
 ```powershell
-doppler login                          # browser auth
-doppler projects create bryandebaun    # or create it in the dashboard
-doppler setup                          # reads doppler.yaml → bryandebaun / dev
+doppler login                            # browser auth
+doppler projects create bryandebaun-dev  # or create it in the dashboard
+doppler setup                            # reads doppler.yaml → bryandebaun-dev / dev
 doppler secrets upload .env.local      # push local values into the dev config (one time)
 ```
 
@@ -29,7 +29,7 @@ Populate `prd` with production values in the dashboard (or `doppler secrets set
 
 ```powershell
 doppler login
-doppler setup            # auto-selects bryandebaun / dev from doppler.yaml
+doppler setup            # auto-selects bryandebaun-dev / dev from doppler.yaml
 doppler run -- pnpm dev  # injects secrets into the process
 ```
 

--- a/doppler.yaml
+++ b/doppler.yaml
@@ -11,5 +11,5 @@
 #
 # Docs: https://docs.doppler.com/docs/cli  •  See docs/secrets-doppler.md
 setup:
-  project: bryandebaun
+  project: bryandebaun-dev
   config: dev

--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,0 +1,15 @@
+# Doppler CLI project scope for this repo.
+#
+# `doppler setup` reads this file to auto-select the Doppler project + config on
+# any machine, so the same secrets resolve on your PC and your Mac without ever
+# copying a .env file around. This file contains NO secret values — safe to commit.
+#
+# First-time setup on a machine:
+#   doppler login          # browser auth, once per machine
+#   doppler setup          # reads the block below; no interactive prompts
+#   doppler run -- pnpm dev
+#
+# Docs: https://docs.doppler.com/docs/cli  •  See docs/secrets-doppler.md
+setup:
+  project: bryandebaun
+  config: dev


### PR DESCRIPTION
## What

Adopts [Doppler](https://www.doppler.com/) as the secrets source of truth (configs
`dev` local / `prd` Vercel) and adds the previously-missing `.env.example`. Follows the
pattern piloted in `bad-mcp`.

- `.env.example` — documents every variable the app reads, **placeholder values only**.
- `doppler.yaml` — pins project `bryandebaun-dev` / config `dev`; every machine
  auto-configures with `doppler setup`.
- `.gitignore` — opts `.env.example` in (the `.env*` rule otherwise ignored it).
- `docs/secrets-doppler.md` — setup, daily use, Vercel integration, rotation.

## Why

Central source of truth, cross-machine sync without copying `.env` files, audit trail,
and a clean rotation path. `NEXT_PUBLIC_*` values remain build-time public.

## Design notes

- **Non-invasive:** package scripts unchanged — run via `doppler run -- <script>`.
- No secret values are committed; `.env.example` is placeholders only.

## Follow-ups (not in this PR)

- [ ] Create Doppler project `bryandebaun-dev`; upload `dev` from `.env.local`
- [ ] Populate `prd` + wire Doppler ↔ Vercel native integration
- [ ] Rotate sensitive secrets (MCP_API_KEY, SUPABASE_SECRET_KEY, RESEND_API_KEY, REVALIDATE_SECRET, GITHUB_TOKEN, GITHUB/GOOGLE OAuth secrets, VERCEL_MCP_TOKEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
