### PR TITLE
chore: upgrade pnpm 10.34.1 → 11.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,17 +2,9 @@
   "name": "bryandebaun.dev",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@10.34.1",
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "engines": {
     "node": ">=24"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "protobufjs",
-      "sharp",
-      "unrs-resolver"
-    ]
   },
   "scripts": {
     "dev": "next dev --turbopack",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,12 @@
 packages:
   - "packages/*"
+
+# Supply-chain allowlist: only these dependencies may run install/build scripts.
+# pnpm 11 records per-package boolean decisions under `allowBuilds` here; the old
+# package.json `pnpm.onlyBuiltDependencies` field is no longer read
+# (see https://pnpm.io/settings). protobufjs (previously allowlisted) is omitted
+# because pnpm 11 does not flag it as having a pending build script.
+allowBuilds:
+  esbuild: true
+  sharp: true
+  unrs-resolver: true


### PR DESCRIPTION
Bumps the pinned package manager to **pnpm 11.9.0** (corepack-verified integrity hash), done deliberately as its own PR rather than sneaking into a feature branch.

## The one real migration
pnpm 11 **no longer reads `pnpm.onlyBuiltDependencies` from `package.json`** (it prints a warning and silently ignores it). The supply-chain build allowlist moves to `pnpm-workspace.yaml` as **`allowBuilds`** (per-package booleans — see https://pnpm.io/settings). Without this, `esbuild`, `sharp`, and `unrs-resolver` install/build scripts are skipped (`ERR_PNPM_IGNORED_BUILDS`).

```yaml
allowBuilds:
  esbuild: true
  sharp: true
  unrs-resolver: true
```

The old `pnpm` block is removed from `package.json`. `protobufjs` is dropped — pnpm 11 doesn't flag it as having a pending build script.

## Why this is low-risk
- **`pnpm-lock.yaml` is unchanged** — `lockfileVersion: 9.0` is compatible with pnpm 11, so there's no lockfile-format churn.
- **`pnpm install --frozen-lockfile` passes** — exactly what Vercel (`installCommand`) and every CI workflow run, so the deploy can't break on a lockfile mismatch.
- **CI needs no edits** — all workflows use `pnpm/action-setup@v4` with no `version:` input, so they read the version from the `packageManager` field automatically.

## Verified locally under pnpm 11.9.0
- Clean install runs the three build scripts (esbuild / sharp / unrs-resolver → Done); no more ignored-builds warning.
- `pnpm run build:packages`, `pnpm test` (15/15), and `pnpm exec eslint` (native `unrs-resolver` resolver) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)