### PR TITLE
feat(resume): enforce the 3-download-per-approval cap (#145)

### DIFF
--- a/packages/mcp-client/src/api-client.ts
+++ b/packages/mcp-client/src/api-client.ts
@@ -1112,17 +1112,17 @@ export class Api<
       }),
 
     /**
-     * @description Record a download against the caller's own approved request. Increments downloadCount and flips status to fulfilled; only valid within the window.
+     * @description Record a download against an approved request and enforce the cap (#145). Server-to-server (API-key): the website's download route calls this before serving the PDF. Atomically increments downloadCount and flips status to fulfilled once the cap (3) is reached.
      *
      * @tags ResumeDownloadRequests
-     * @name FulfillRequest
-     * @request PATCH:/api/resumeDownloadRequests/{id}/fulfill
+     * @name RecordDownload
+     * @request POST:/api/resumeDownloadRequests/{id}/record-download
      * @secure
      */
-    fulfillRequest: (id: string, params: RequestParams = {}) =>
+    recordDownload: (id: string, params: RequestParams = {}) =>
       this.request<ResumeDownloadRequest, void>({
-        path: `/api/resumeDownloadRequests/${id}/fulfill`,
-        method: "PATCH",
+        path: `/api/resumeDownloadRequests/${id}/record-download`,
+        method: "POST",
         secure: true,
         format: "json",
         ...params,

--- a/src/app/api/resume/download/__tests__/route.test.ts
+++ b/src/app/api/resume/download/__tests__/route.test.ts
@@ -1,0 +1,102 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mutable handles for the token verifier, signed-URL minter, and the
+// download-recording service call.
+const verifyResumeDownloadLink = vi.fn();
+const getResumeDownloadSignedUrl = vi.fn();
+const recordResumeDownload = vi.fn();
+
+vi.mock('@/lib/resume-download', () => ({
+    verifyResumeDownloadLink: (...a: unknown[]) =>
+        verifyResumeDownloadLink(...a),
+    getResumeDownloadSignedUrl: (...a: unknown[]) =>
+        getResumeDownloadSignedUrl(...a),
+}));
+
+vi.mock('@/lib/services/resume-requests', () => ({
+    recordResumeDownload: (...a: unknown[]) => recordResumeDownload(...a),
+}));
+
+function makeReq(token?: string): NextRequest {
+    const base = 'http://localhost/api/resume/download';
+    const url =
+        token === undefined ? base : `${base}?t=${encodeURIComponent(token)}`;
+    return new NextRequest(url);
+}
+
+describe('GET /api/resume/download', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        verifyResumeDownloadLink.mockReturnValue({
+            ok: true,
+            requestId: 'req-1',
+        });
+        getResumeDownloadSignedUrl.mockResolvedValue({
+            ok: true,
+            url: 'https://storage.example/signed?token=abc',
+            expiresInSeconds: 259200,
+        });
+        recordResumeDownload.mockResolvedValue({
+            ok: true,
+            request: { id: 'req-1', downloadCount: 1 },
+        });
+    });
+
+    it('404s on an invalid/missing token and never touches storage or the count', async () => {
+        verifyResumeDownloadLink.mockReturnValue({ ok: false });
+        const { GET } = await import('../route');
+        const res = await GET(makeReq('bad'));
+        expect(res.status).toBe(404);
+        expect(getResumeDownloadSignedUrl).not.toHaveBeenCalled();
+        expect(recordResumeDownload).not.toHaveBeenCalled();
+    });
+
+    it('404s (and does NOT record) when the PDF object is missing', async () => {
+        getResumeDownloadSignedUrl.mockResolvedValue({
+            ok: false,
+            reason: 'not_found',
+        });
+        const { GET } = await import('../route');
+        const res = await GET(makeReq('good'));
+        expect(res.status).toBe(404);
+        expect(recordResumeDownload).not.toHaveBeenCalled();
+    });
+
+    it('503s (and does NOT record) on a transient storage error', async () => {
+        getResumeDownloadSignedUrl.mockResolvedValue({
+            ok: false,
+            reason: 'error',
+        });
+        const { GET } = await import('../route');
+        const res = await GET(makeReq('good'));
+        expect(res.status).toBe(503);
+        expect(recordResumeDownload).not.toHaveBeenCalled();
+    });
+
+    it('410s when the cap/expiry is reached (backend denies the record)', async () => {
+        recordResumeDownload.mockResolvedValue({ ok: false, reason: 'denied' });
+        const { GET } = await import('../route');
+        const res = await GET(makeReq('good'));
+        expect(res.status).toBe(410);
+        const json = await res.json();
+        expect(json.error).toMatch(/limit|expired/i);
+    });
+
+    it('503s when recording fails transiently (never serves unrecorded)', async () => {
+        recordResumeDownload.mockResolvedValue({ ok: false, reason: 'error' });
+        const { GET } = await import('../route');
+        const res = await GET(makeReq('good'));
+        expect(res.status).toBe(503);
+    });
+
+    it('302-redirects to the signed URL once the download is recorded', async () => {
+        const { GET } = await import('../route');
+        const res = await GET(makeReq('good'));
+        expect(res.status).toBe(302);
+        expect(res.headers.get('location')).toBe(
+            'https://storage.example/signed?token=abc',
+        );
+        expect(recordResumeDownload).toHaveBeenCalledWith('req-1');
+    });
+});

--- a/src/app/api/resume/download/route.ts
+++ b/src/app/api/resume/download/route.ts
@@ -3,6 +3,7 @@ import {
     getResumeDownloadSignedUrl,
     verifyResumeDownloadLink,
 } from '@/lib/resume-download';
+import { recordResumeDownload } from '@/lib/services/resume-requests';
 
 // This route mints a fresh, short-lived signed URL per request and must never
 // be cached or statically prerendered.
@@ -28,6 +29,8 @@ export async function GET(req: NextRequest) {
     const verified = verifyResumeDownloadLink(token);
     if (!verified.ok) return notFoundResponse();
 
+    // Mint the signed URL FIRST: if the object is missing/unconfigured we bail
+    // before recording, so a broken file never burns one of the user's downloads.
     const result = await getResumeDownloadSignedUrl();
     if (!result.ok) {
         // `unconfigured`/`not_found` → 404 (reveal nothing); transient storage
@@ -39,6 +42,25 @@ export async function GET(req: NextRequest) {
             );
         }
         return notFoundResponse();
+    }
+
+    // Record the download and enforce the per-approval cap (#145). This is the
+    // authoritative gate — the backend atomically increments the count and
+    // rejects once the cap/expiry is reached. Only redirect on a recorded 2xx.
+    const recorded = await recordResumeDownload(verified.requestId);
+    if (!recorded.ok) {
+        if (recorded.reason === 'denied') {
+            return NextResponse.json(
+                {
+                    error: 'This download link has reached its limit or expired.',
+                },
+                { status: 410 },
+            );
+        }
+        return NextResponse.json(
+            { error: 'The résumé is temporarily unavailable.' },
+            { status: 503 },
+        );
     }
 
     return NextResponse.redirect(result.url, 302);

--- a/src/lib/services/resume-requests.ts
+++ b/src/lib/services/resume-requests.ts
@@ -71,3 +71,40 @@ export async function denyResumeRequest(
     const res = await api.api.denyRequest(id, body);
     return unwrapApiResponse<ResumeDownloadRequest>(res);
 }
+
+export type RecordDownloadResult =
+    | { ok: true; request: ResumeDownloadRequest }
+    | { ok: false; reason: 'denied' | 'error' };
+
+/**
+ * Record a download against an approved request and enforce the per-approval
+ * cap (#145). Server-to-server (API-key, no user token) — the public download
+ * route calls this before serving the PDF; the backend atomically increments
+ * `downloadCount` and flips `status` to `fulfilled` once the cap is hit.
+ *
+ * Returns a discriminated result rather than throwing:
+ *  - `denied` — the request is no longer serviceable (at cap, expired, denied,
+ *    or not found): any 4xx. The caller should refuse the download.
+ *  - `error` — a transient/server failure (5xx/network): the caller should
+ *    surface a retryable error and NOT serve, so downloads are only ever served
+ *    when they were successfully recorded.
+ */
+export async function recordResumeDownload(
+    id: string,
+): Promise<RecordDownloadResult> {
+    try {
+        const api = createApi();
+        const res = await api.api.recordDownload(id);
+        return {
+            ok: true,
+            request: unwrapApiResponse<ResumeDownloadRequest>(res),
+        };
+    } catch (e) {
+        const status = (e as { response?: { status?: number } })?.response
+            ?.status;
+        if (typeof status === 'number' && status >= 400 && status < 500) {
+            return { ok: false, reason: 'denied' };
+        }
+        return { ok: false, reason: 'error' };
+    }
+}


### PR DESCRIPTION
Finishes the Phase 2 download story now that the backend record-download endpoint (mcp-server #145) is deployed.

## What
- Regenerated the MCP client → `recordDownload(id)` (`POST /api/resumeDownloadRequests/{id}/record-download`).
- `recordResumeDownload(id)` service wrapper — server-to-server (API-key), discriminated result (`denied | error`).
- Wired `GET /api/resume/download` to **record before serving**:
  1. verify the signed token → bare 404 on failure;
  2. mint the signed URL **first** (a missing PDF never burns one of the user's 3 downloads);
  3. `recordResumeDownload` — the backend atomically increments `downloadCount` and flips `status` to `fulfilled` at the cap;
  4. `denied` (4xx: at-cap / expired) → **410** "limit reached or expired"; `error` (5xx/network) → **503** so nothing is ever served un-recorded;
  5. else 302 to the signed URL.

## Tests
New route tests cover the full matrix (invalid token → 404, missing file → 404 w/o recording, storage error → 503 w/o recording, cap → 410, record error → 503, success → 302 + records once). 27 resume-suite tests pass; ESLint (CI gate) exit 0; Biome clean; client compiles.

Closes the frontend half of the #145 follow-up. Builds on #123 (Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)