### PR TITLE
chore: enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,97 @@
+version: 2
+
+# Dependency updates + vulnerability alerts.
+#
+# Grouped and batched deliberately, following the same reasoning as the
+# mcp-server config: this is a solo project, and a dozen individual PRs a week
+# is how Dependabot gets muted. A muted bot is worse than none — it looks like
+# coverage while providing none. CI is the gate; majors are the only thing that
+# arrives alone and gets read.
+#
+# GROUP ORDER MATTERS. Dependabot assigns a dependency to the FIRST group whose
+# patterns match it, so every specific group below has to be declared ABOVE the
+# catch-all at the bottom. Move `minor-and-patch` up and it swallows everything.
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+    labels:
+      - 'infra'
+      - 'type:chore'
+    groups:
+      # Next and its ESLint config are both pinned exact and must move in
+      # lockstep — eslint-config-next validates against a specific Next
+      # version. Split across two PRs, neither one is mergeable on its own.
+      # Majors included for the same reason.
+      next:
+        patterns:
+          - 'next'
+          - 'eslint-config-next'
+      # Same story: react and react-dom are pinned exact, and their @types have
+      # to match the runtime version or every component file lights up. One PR,
+      # all four packages, majors included.
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
+      # The browser-test toolchain, kept OUT of the general minor/patch PR.
+      #
+      # A Playwright bump ships a new Chromium, which shifts pixel output and
+      # churns the a11y-visual baselines. An axe-core bump adds rules, which
+      # changes what the a11y suite reports. Both are expected churn — and that
+      # is exactly the problem: folded into a thirty-package PR, a REAL visual
+      # regression is indistinguishable from the baseline noise around it. On
+      # its own, the diff is reviewable and the regenerated screenshots are
+      # worth looking at.
+      browser-tests:
+        patterns:
+          - 'playwright'
+          - '@playwright/*'
+          - 'lighthouse'
+          - 'chrome-launcher'
+          - 'axe-core'
+          - 'vitest-axe'
+          - 'pixelmatch'
+          - '@types/pixelmatch'
+          - 'pngjs'
+          - '@types/pngjs'
+      # Everything else, minor and patch, in one PR. CI (lint + typecheck +
+      # unit + content checks) is the gate; reviewing these individually has no
+      # payoff.
+      minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # @types/node tracks the Node major that CI and Vercel actually run, not
+      # npm's latest. Types AHEAD of the runtime are the dangerous direction:
+      # tsc accepts an API that does not exist on the deployed Node, every gate
+      # passes green, and it throws in production. The type layer is the only
+      # thing that could have known. Move this with the workflow node-version
+      # pins.
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
+    # This is a pnpm workspace — the root lockfile covers packages/*, so one
+    # entry is enough. @bryandebaun/mcp-client is `workspace:*` and is not a
+    # registry dependency, so Dependabot leaves it alone; it is regenerated
+    # from the MCP server's OpenAPI schema, not versioned.
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - 'infra'
+      - 'type:chore'
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
Closes #127

Adds `.github/dependabot.yml` covering `npm` (weekly) and `github-actions` (monthly), following the pattern already running in mcp-server.

### Grouping

Specific groups are declared **above** the catch-all, because Dependabot assigns a dependency to the first group whose patterns match it. Reversed, `minor-and-patch` swallows everything.

- **`next`** — `next` + `eslint-config-next`, majors included. Both pinned exact and version-coupled; split across PRs, neither is mergeable alone.
- **`react`** — `react`, `react-dom`, and both `@types`, majors included. Types have to match the runtime version or every component file lights up.
- **`browser-tests`** — Playwright, Lighthouse, axe-core, pixelmatch and friends, kept out of the general PR. A Playwright bump ships a new Chromium and churns the `a11y-visual` baselines; an axe-core bump changes what the a11y suite reports. That churn is expected, which is exactly the problem: folded into a thirty-package PR, a real visual regression is indistinguishable from the noise around it.
- **`minor-and-patch`** — everything else in one PR, gated by CI.

Majors outside those groups still arrive individually.

### Ignores

`@types/node` majors only. It tracks the Node major CI and Vercel run, not npm's latest — and types ahead of the runtime is the direction that hurts: `tsc` accepts an API the deployed Node doesn't have, every gate passes, and it throws in production.

### Notes

Config-only. Nothing here changes the build, the app, or any installed version — it adds a file GitHub reads on a schedule. The updates it proposes get reviewed as their own PRs, tracked in #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)