### PR TITLE
fix(ci): stop the MCP client check failing on every Dependabot PR

### DIFF
--- a/.github/workflows/verify-mcp-client.yml
+++ b/.github/workflows/verify-mcp-client.yml
@@ -26,18 +26,57 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Download OpenAPI spec (optional)
+      # This job cannot run without MCP_API_KEY, and on Dependabot PRs it will
+      # not have one.
+      #
+      # GitHub deliberately withholds *Actions* secrets from workflows triggered
+      # by Dependabot — a Dependabot PR runs with a separate, read-only token and
+      # its own `secrets.DEPENDABOT_*` scope. So `secrets.MCP_API_KEY` expands to
+      # an empty string, the generator hits the MCP server unauthenticated, gets
+      # something that is not a spec back, and dies with:
+      #
+      #   S2OError: Unsupported swagger/OpenAPI version: undefined
+      #
+      # which reads as "the generated client is broken" when the real cause is a
+      # missing credential. Left alone it makes this check permanently red on
+      # every single Dependabot PR — and a check that is always red is a check
+      # nobody reads, which defeats the point of running the bot at all.
+      #
+      # TO RESTORE FULL COVERAGE: add MCP_API_KEY under
+      #   Settings -> Secrets and variables -> Dependabot
+      # (that page is separate from the Actions one; adding it there does NOT
+      # add it here). Once it exists, this guard stops tripping on its own and
+      # Dependabot PRs get verified like any other.
+      - name: Check whether the MCP API key is available
+        id: key
+        env:
+          MCP_API_KEY: ${{ secrets.MCP_API_KEY }}
         run: |
-          mkdir -p artifacts/openapi
-          echo "Attempting to download OpenAPI spec to artifacts/openapi/bad-mcp.swagger.json"
-          curl --fail --silent --show-error --retry 5 --retry-delay 5 --max-time 60 -sS "$MCP_OPENAPI_URL" -o artifacts/openapi/bad-mcp.swagger.json || echo "Couldn't download spec; generator will try remote directly or fallback to committed spec."
+          if [ -z "$MCP_API_KEY" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=MCP client verification skipped::MCP_API_KEY is unavailable, so the generated client could not be regenerated or compared. On Dependabot PRs this is expected until the key is added under Settings > Secrets and variables > Dependabot. Anywhere else it means the Actions secret is missing."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
 
+      # The "Download OpenAPI spec (optional)" step that used to sit here has
+      # been removed. It curled "$MCP_OPENAPI_URL", which was never passed into
+      # the step's environment, so the variable was always empty, the curl
+      # always failed, and every run printed "Couldn't download spec" before
+      # carrying on regardless. It did nothing except make a healthy log look
+      # like a broken one.
+      #
+      # Nothing is lost: scripts/generate-mcp-client.ts reads MCP_OPENAPI_URL
+      # itself and falls back to the public swagger.json, so the generator was
+      # already doing this download properly one step later.
       - name: Generate MCP client
+        if: steps.key.outputs.available == 'true'
         run: pnpm run generate:mcp-client
         env:
           MCP_API_KEY: ${{ secrets.MCP_API_KEY }}
 
       - name: Verify generated files are up-to-date
+        if: steps.key.outputs.available == 'true'
         run: |
           # Check for uncommitted changes to generated client
           if [ -n "$(git status --porcelain packages/mcp-client/src)" ]; then


### PR DESCRIPTION
Blocks #128. Found while triaging the Dependabot backlog: **"Verify MCP client generation" failed on all six** Dependabot PRs, including ones that touch nothing it covers.

It isn't a real failure.

### What's actually happening

GitHub **deliberately withholds Actions secrets from Dependabot-triggered workflows** — they run with a separate read-only token and their own secrets scope. So `secrets.MCP_API_KEY` expands to an empty string. The run log shows it plainly:

```
MCP_API_KEY: 
```

The generator then hits the MCP server unauthenticated, gets back something that isn't a spec, and dies with:

```
S2OError: Unsupported swagger/OpenAPI version: undefined
```

…which reads as *"the generated client is broken"* when the real cause is a missing credential.

**Confirmed by comparison, not assumed:** the same workflow **passed** on `chore/enable-dependabot` at 14:24 and **failed** on all six `dependabot/*` branches from 14:32 onward. Nothing about the generated client changed in between.

### Why this is worth fixing rather than ignoring

A check that's red on *every* bot PR is a check nobody reads — and the entire reason the grouped `dependabot.yml` exists is to keep these PRs worth looking at. A permanently-failing check trains you to merge past red, which is strictly worse than having no check.

The job now detects the missing key and **skips its remaining steps with a `::warning` annotation naming the cause**, rather than failing. That trades a false red for a visible gap, which is the right way round.

### Action needed from you to restore full coverage

Add `MCP_API_KEY` under **Settings → Secrets and variables → Dependabot**.

That page is separate from the Actions one — adding it in Actions does *not* add it there. Once the secret exists, the guard stops tripping on its own and Dependabot PRs get verified like any other. No further change to this file.

Worth doing: until then, a `swagger-typescript-api` bump (it's in the `minor-and-patch` group) could change the generated client and this check wouldn't catch it.

### Also removed: a step that never worked

`Download OpenAPI spec (optional)` curled `"$MCP_OPENAPI_URL"`, which was **never passed into the step's environment**. The variable was always empty, so the curl always failed — on every branch, including passing ones — and printed `Couldn't download spec` every run. It only ever made a healthy log look broken.

Nothing is lost: `scripts/generate-mcp-client.ts` reads `MCP_OPENAPI_URL` itself and falls back to the public `swagger.json`, so the real download already happened one step later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)