### PR TITLE
chore(deps): bump @supabase/ssr to 0.12.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@bryandebaun/mcp-client": "workspace:*",
     "@radix-ui/react-select": "^2.3.7",
-    "@supabase/ssr": "^0.10.2",
+    "@supabase/ssr": "^0.12.4",
     "@supabase/supabase-js": "^2.111.0",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-table": "^8.21.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^2.3.7
         version: 2.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@supabase/ssr':
-        specifier: ^0.10.2
-        version: 0.10.2(@supabase/supabase-js@2.111.0)
+        specifier: ^0.12.4
+        version: 0.12.4(@supabase/supabase-js@2.111.0)
       '@supabase/supabase-js':
         specifier: ^2.111.0
         version: 2.111.0
@@ -1746,10 +1746,10 @@ packages:
     resolution: {integrity: sha512-6oRf/vZyRwg8f8GbFSJkrD2w4HAu/yTvyMViHXHS+H5hNJzdXCrUR7cP5oW7daT3YlRnzRPY9LcGSJKZAmfMSg==}
     engines: {node: '>=22.0.0'}
 
-  '@supabase/ssr@0.10.2':
-    resolution: {integrity: sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==}
+  '@supabase/ssr@0.12.4':
+    resolution: {integrity: sha512-xHzcgI8cC1TpBKSwJcR5Yd8CCwfIq0SBc5yb4yz/YFw5tbCrEQ0QT3a+2jymCxHgQWLfzwN93HZ6eRbcoMkOlA==}
     peerDependencies:
-      '@supabase/supabase-js': ^2.102.1
+      '@supabase/supabase-js': ^2.111.0
 
   '@supabase/storage-js@2.111.0':
     resolution: {integrity: sha512-UEViNmTzVOxE8dqUA81wls+n9xgmlvSFfhfwo6QxrO4kQOytCYyw3ciYFoi4XoD4Jl95NJ3jnndHN5iIudWzqw==}
@@ -6798,7 +6798,7 @@ snapshots:
       '@supabase/phoenix': 0.4.5
       tslib: 2.8.1
 
-  '@supabase/ssr@0.10.2(@supabase/supabase-js@2.111.0)':
+  '@supabase/ssr@0.12.4(@supabase/supabase-js@2.111.0)':
     dependencies:
       '@supabase/supabase-js': 2.111.0
       cookie: 1.1.1


### PR DESCRIPTION
Part of #128. The package held back from #139.

`@supabase/ssr` **0.10.2 → 0.12.4**.

### Why it got its own PR

A `0.x` package crossing **two minors** is two breaking changes under semver. Dependabot batched it into `minor-and-patch` because it classifies update-types by version number rather than semver meaning — and on this package that's the wrong call. `@supabase/ssr` is the SSR cookie and session layer **every authenticated request passes through**. A silent behaviour change there is an auth bug, not a failing test.

### What I actually checked, beyond the green build

The two call sites are `src/lib/supabase/client.ts` (`createBrowserClient`) and `src/lib/supabase/server.ts` (`createServerClient`).

The server one already uses the **`getAll`/`setAll`** cookie interface rather than the deprecated `get`/`set`/`remove` trio that older `0.x` releases exposed. So the API surface this repo depends on is the current one — which is why a two-minor jump lands clean instead of silently changing how cookies are written.

### Verification

`pnpm run build`, **387 tests across 82 files**, `eslint` clean.

### What is *not* verified

**No test exercises a real cookie round-trip through `createServerClient`.** "Sessions still persist" rests on the API surface being unchanged, not on a test proving it. The unit suite mocks Supabase rather than hitting it.

**Worth a login and a page refresh on the Vercel preview before this reaches production** — that's the one check that would actually catch a session-handling regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)